### PR TITLE
fix: adjust padding on package link section on desktop

### DIFF
--- a/lib/toolbox_web/components/package_link.ex
+++ b/lib/toolbox_web/components/package_link.ex
@@ -8,10 +8,10 @@ defmodule ToolboxWeb.Components.PackageLink do
 
   def package_link(assigns) do
     ~H"""
-    <.link class="flex items-center text-[14px] py-2 sm:px-4" href={@href} target="_blank">
+    <.link class="flex items-center text-[14px] py-2" href={@href} target="_blank">
       <img src={@icon_path} class="mr-2 sm:w-4" />
       <span class="sm:mt-0 mr-2">{@text}</span>
-      <img src={~p"/images/right-chevron-icon.svg"} class="mr-2 ml-auto" />
+      <img src={~p"/images/right-chevron-icon.svg"} class="ml-auto" />
     </.link>
     """
   end


### PR DESCRIPTION
Before
![Screenshot 2025-04-25 at 12 17 14 PM](https://github.com/user-attachments/assets/bb7aa178-99d5-4ca3-99e0-90afdfd25029)

After
![Screenshot 2025-04-25 at 12 17 26 PM](https://github.com/user-attachments/assets/f1fcb133-abcc-495a-9dcc-a6e8e669dbbc)
