### PR TITLE
fix: makes search case insensitive

### DIFF
--- a/lib/toolbox/packages.ex
+++ b/lib/toolbox/packages.ex
@@ -25,7 +25,7 @@ defmodule Toolbox.Packages do
     {packages, rest} =
       from(
         p in Package,
-        where: like(p.name, ^like_term),
+        where: ilike(p.name, ^like_term),
         join: s in subquery(latest_hexpm_snaphost_query()),
         on: s.package_id == p.id,
         preload: [


### PR DESCRIPTION
Searching for "Bandit" should find bandit package e.g.

https://hexdocs.pm/ecto/Ecto.Query.API.html#ilike/2