### PR TITLE
fix: hint mobile virtual keyboard to not autocapitalize search term

### DIFF
--- a/lib/toolbox_web/components/search_field_component.ex
+++ b/lib/toolbox_web/components/search_field_component.ex
@@ -19,6 +19,7 @@ defmodule ToolboxWeb.SearchFieldComponent do
           class="grow border-0 focus:ring-0 bg-transparent dark:text-white"
           required
           autofocus={@autofocus}
+          autocapitalize="off"
         />
         <button class="p-2">
           <.icon name="hero-magnifying-glass" />


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/autocapitalize