### PR TITLE
chore: Add index on snapshots, improve performance

### DIFF
--- a/priv/repo/migrations/20250506165604_create_index_on_snapshots.exs
+++ b/priv/repo/migrations/20250506165604_create_index_on_snapshots.exs
@@ -1,0 +1,10 @@
+defmodule Toolbox.Repo.Migrations.CreateIndexOnSnapshots do
+  use Ecto.Migration
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  def change do
+    create index(:hexpm_snapshots, ["package_id, id DESC"], concurrently: true)
+    create index(:github_snapshots, ["package_id, id DESC"], concurrently: true)
+  end
+end


### PR DESCRIPTION
When fetching packages with latest snapshot and for search we are always using partition and group by id and package_id

Before:

```sql
Limit  (cost=7574.68..7574.69 rows=1 width=67)
  ->  Sort  (cost=7574.68..7574.69 rows=1 width=67)
"        Sort Key: ((sh0.data #> '{downloads,recent}'::text[])) DESC"
        ->  Nested Loop  (cost=5982.48..7574.67 rows=1 width=67)
              ->  Nested Loop  (cost=5982.20..7533.69 rows=120 width=1226)
                    ->  Subquery Scan on ss1  (cost=5981.91..6765.09 rows=120 width=8)
                          Filter: (ss1.row_number = 1)
                          ->  WindowAgg  (cost=5981.91..6463.87 rows=24098 width=24)
                                Run Condition: (row_number() OVER (?) <= 1)
                                ->  Sort  (cost=5981.91..6042.15 rows=24098 width=16)
                                      Sort Key: ssh0.package_id, ssh0.id DESC
                                      ->  Seq Scan on hexpm_snapshots ssh0  (cost=0.00..4227.98 rows=24098 width=16)
                    ->  Index Scan using hexpm_snapshots_pkey on hexpm_snapshots sh0  (cost=0.29..6.40 rows=1 width=1234)
                          Index Cond: (id = ss1.id)
              ->  Index Scan using packages_pkey on packages p0  (cost=0.29..0.34 rows=1 width=35)
                    Index Cond: (id = sh0.package_id)
"                    Filter: ((name)::text = '%bandit%'::text)"
```

After:
```sql
Limit  (cost=3662.63..3662.64 rows=1 width=67)
  ->  Sort  (cost=3662.63..3662.64 rows=1 width=67)
"        Sort Key: ((sh0.data #> '{downloads,recent}'::text[])) DESC"
        ->  Nested Loop  (cost=0.57..3662.62 rows=1 width=67)
              Join Filter: (sh0.id = ss1.id)
              ->  Nested Loop  (cost=0.29..381.83 rows=1 width=1261)
                    ->  Seq Scan on packages p0  (cost=0.00..373.51 rows=1 width=35)
"                          Filter: ((name)::text = '%bandit%'::text)"
"                    ->  Index Scan using ""hexpm_snapshots_package_id__id_DESC_index"" on hexpm_snapshots sh0  (cost=0.29..8.30 rows=1 width=1234)"
                          Index Cond: (package_id = p0.id)
              ->  Subquery Scan on ss1  (cost=0.29..3279.29 rows=120 width=8)
                    Filter: (ss1.row_number = 1)
                    ->  WindowAgg  (cost=0.29..2978.07 rows=24098 width=24)
                          Run Condition: (row_number() OVER (?) <= 1)
"                          ->  Index Only Scan using ""hexpm_snapshots_package_id__id_DESC_index"" on hexpm_snapshots ssh0  (cost=0.29..2556.35 rows=24098 width=16)"
```

Still need to improve the ILIKE search and the sort key.