### PR TITLE
fix(landing) remove autocomplete in search

### DIFF
--- a/lib/toolbox_web/components/search_field_component.ex
+++ b/lib/toolbox_web/components/search_field_component.ex
@@ -19,6 +19,7 @@ defmodule ToolboxWeb.SearchFieldComponent do
           class="grow border-0 focus:ring-0 bg-transparent text-white placeholder:text-gray-400"
           required
           autofocus={@autofocus}
+          autocomplete="off"
           autocapitalize="off"
         />
         <button type="submit" class="flex items-center justify-center">


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/b057f087-4361-4a64-98ce-efa8807e6b83)


After:
![image](https://github.com/user-attachments/assets/5088933c-d12d-402e-a1bc-50e232195d07)
