### PR TITLE
feat(package-show): show owners as designed

### DIFF
--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -210,16 +210,16 @@
       </div>
     </div>
 
-    <div class="md:col-span-2 bg-zinc-100 dark:bg-surface rounded-md py-6 px-4 border border-stroke">
-      <h3 class="text-[24px] font-medium mb-5">
+    <div class="md:col-span-2 bg-zinc-100 dark:bg-surface rounded-md px-5 py-3 sm:p-8 border border-stroke">
+      <h3 class="text-[14px] sm:text-[24px] font-medium mb-3 sm:mb-5">
         Owners
       </h3>
 
-      <ul class="flex flex-col">
-        <li :for={owner <- @package.owners} class="flex items-center mb-3">
+      <ul class="flex sm:flex-col flex-wrap">
+        <li :for={owner <- @package.owners} class="flex items-center mb-3 w-1/2">
           <img width="32px" height="32px" class="rounded-full" src={gravatar_url(owner["email"])} />
 
-          <span class="text-[14px] ml-2">
+          <span class="text-[14px] text-[16px] ml-2">
             <.user_link username={owner["username"]} />
           </span>
         </li>


### PR DESCRIPTION
Before
<img width="333" alt="Screenshot 2025-05-06 at 4 34 44 PM" src="https://github.com/user-attachments/assets/135df4b2-ad32-4fc4-a47a-1602134cbe60" />
<img width="438" alt="Screenshot 2025-05-06 at 4 35 05 PM" src="https://github.com/user-attachments/assets/2865ee33-5760-47de-8f2d-44a5432c81ad" />

After
<img width="413" alt="Screenshot 2025-05-06 at 4 35 56 PM" src="https://github.com/user-attachments/assets/30c90667-8b4f-4beb-87f6-5c7392027aee" />
<img width="369" alt="Screenshot 2025-05-06 at 4 36 04 PM" src="https://github.com/user-attachments/assets/8433d2ec-f767-4230-8606-ca6fc9f489a6" />
