### PR TITLE
fix: search page header as designed

### DIFF
--- a/lib/toolbox_web/live/search_live.html.heex
+++ b/lib/toolbox_web/live/search_live.html.heex
@@ -1,5 +1,5 @@
 <article class="pt-8 sm:pt-15">
-  <div class="flex items-center justify-between">
+  <div class="flex items-baseline justify-between">
     <h1 class="text-[32px] text-primary-text font-bold">
       {length(@packages)}{if(@more?, do: "+")} results for "{@term}"
     </h1>


### PR DESCRIPTION
Before
<img width="1470" alt="Screenshot 2025-05-10 at 12 47 17 PM" src="https://github.com/user-attachments/assets/1c66d16b-5499-4fd2-bce7-a9b01ea8d32f" />

After
<img width="1470" alt="Screenshot 2025-05-10 at 12 47 27 PM" src="https://github.com/user-attachments/assets/b7eb6f3c-9c6c-4764-b224-ac596b1dda51" />
