### PR TITLE
fix(about): fix about page bg issues and layout enhancements

### DIFF
--- a/lib/toolbox_web/components/layouts/home.html.heex
+++ b/lib/toolbox_web/components/layouts/home.html.heex
@@ -1,5 +1,5 @@
-<main class="flex flex-col h-full justify-around sm:justify-between bg-black bg-[url('/images/light-home-bg.svg')] dark:bg-[url('/images/home-bg.svg')] bg-center bg-no-repeat bg-cover px-5">
-  <div class="container mx-auto grow flex flex-col sm:block">
+<main class="min-h-screen justify-around sm:justify-between bg-black bg-[url('/images/light-home-bg.svg')] dark:bg-[url('/images/home-bg.svg')] bg-center bg-no-repeat bg-cover px-5">
+  <div class="min-h-screen container mx-auto flex flex-col justify-between">
     <nav class="flex justify-between items-center py-3">
       <.link navigate="/" class="text-2xl">
         <.logo />
@@ -12,11 +12,11 @@
       </.link>
     </nav>
     {@inner_content}
-  </div>
 
-  <footer class="flex justify-around mt-auto pb-10 sm:pb-15 container mx-auto text-secondary-text text-[14px] sm:block">
-    <span>
-      Built by <.link href="https://mimiquate.com" target="_blank" class="underline">Mimiquate</.link>.
-    </span>
-  </footer>
+    <footer class="flex justify-around pb-10 sm:pb-15 mx-auto sm:mx-0 text-secondary-text text-[14px] sm:block">
+      <span>
+        Built by <.link href="https://mimiquate.com" target="_blank" class="underline">Mimiquate</.link>.
+      </span>
+    </footer>
+  </div>
 </main>

--- a/lib/toolbox_web/live/about_live.html.heex
+++ b/lib/toolbox_web/live/about_live.html.heex
@@ -1,5 +1,5 @@
 <article class="w-full">
-  <div class="flex flex-col px-5 sm:flex-row justify-between pt-15 mt-15">
+  <div class="flex flex-col sm:flex-row justify-between pt-15 mt-15">
     <div class="sm:max-w-200">
       <h1 class="text-[42px] text-primary-text sm:text-[64px] font-serif font-semibold leading-none">
         The Complete <mark class="text-accent">Elixir</mark> Package Guide
@@ -18,12 +18,12 @@
 
     <img class="w-40 ml-auto sm:w-96 sm:ml-initial" src={~p"/images/about-logo.png"} />
   </div>
-  <div class="relative w-screen left-[50%] right-[50%] -mx-[50vw] flex justify-around px-5 py-15 border-t border-b border-stroke my-15">
+  <div class="relative w-screen left-[50%] right-[50%] -mx-[50vw] flex justify-around py-15 border-t border-b border-stroke my-15">
     <h2 class="text-[24px] text-primary-text text-center font-medium sm:text-left">
       "A tool born from real development needs — <mark class="text-accent">the definitive source for finding and evaluating Elixir solutions</mark>."
     </h2>
   </div>
-  <div class="flex flex-col px-4 sm:flex-row justify-between py-15">
+  <div class="flex flex-col sm:flex-row justify-between py-15">
     <h3 class="text-[48px] text-primary-text sm:min-w-120 font-serif font-semibold sm:leading sm:none">
       The Purpose
     </h3>
@@ -35,7 +35,7 @@
       so teams can focus on building great software.
     </p>
   </div>
-  <div class="relative w-screen left-[50%] right-[50%] -mx-[50vw] px-5 py-15 my-15 border border-stroke bg-accent sm:px-28">
+  <div class="relative w-screen left-[50%] right-[50%] -mx-[50vw] py-15 my-15 border border-stroke bg-accent sm:px-28">
     <div class="absolute inset-0 bg-gradient-to-r from-transparent via-[rgba(33,16,90,0.70)] to-[rgba(33,16,90,0.70)] opacity-100">
     </div>
     <div class="container mx-auto">

--- a/lib/toolbox_web/live/home_live.html.heex
+++ b/lib/toolbox_web/live/home_live.html.heex
@@ -1,5 +1,5 @@
-<div class="h-full w-full flex items-center">
-  <div class="flex flex-col w-full px-4 mt-auto mb-auto sm:block mt-auto mb-auto">
+<div class="w-full flex items-center">
+  <div class="flex flex-col w-full sm:block mt-auto mb-auto">
     <h1 class="font-code text-[48px] sm:text-[72px] text-primary-text">observer</h1>
     <p class="mt-4 sm:text-[14px] text-primary-text sm:text-[20px] font-mono sm:max-w-115">
       Find, compare, and explore Elixir packages for your next project.


### PR DESCRIPTION
Before
![Screenshot 2025-05-22 at 9 44 39 AM](https://github.com/user-attachments/assets/af19964f-a4b3-435e-b6a0-8b4dc8a29d36)

After
![Screenshot 2025-05-22 at 9 44 53 AM](https://github.com/user-attachments/assets/312277cd-ba31-4374-be63-28cff086173d)

The issue here was happening because the layout had a fixed height to se size of the screen and the about page is larger than the screen height.

In order to fix the issue I had to rework the home layout (which the home and about page share) to make it as big as the screen as minimum fot the home page and to continue to work properly when the contents within the layout are larget than the screen height (about page scenario).