### PR TITLE
Revert "chore: use stored hexpm owners in package live (#103)"

### DIFF
--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -46,7 +46,7 @@ defmodule ToolboxWeb.PackageLive do
           %{
             name: package.name,
             description: hexpm_data["meta"]["description"],
-            owners: hexpm_data["owners"],
+            owners: owners(name),
             recent_downloads: hexpm_data["downloads"]["recent"],
             versions: versions,
             latest_version_at: hd(hexpm_data["releases"])["inserted_at"],
@@ -82,6 +82,19 @@ defmodule ToolboxWeb.PackageLive do
     else
       {:noreply, push_patch(socket, to: ~p"/packages/#{name}/#{version}")}
     end
+  end
+
+  defp owners(package_name) do
+    {
+      :ok,
+      {
+        {_, 200, _},
+        _headers,
+        owners_data
+      }
+    } = Toolbox.Hexpm.get_package_owners(package_name)
+
+    Phoenix.json_library().decode!(owners_data)
   end
 
   defp versions(hexpm_data) do


### PR DESCRIPTION
This reverts commit fa06682ea6a2f8f09e039c2ade98362abf7463a5, reversing changes made to f3a69fc630832534911c3f84595fc7ac1f54604a.