### PR TITLE
fix: cache hexpm version api call

### DIFF
--- a/lib/toolbox/hexpm.ex
+++ b/lib/toolbox/hexpm.ex
@@ -28,6 +28,11 @@ defmodule Toolbox.Hexpm do
     )
   end
 
+  @decorate cacheable(key: {:hexpm_version, name, version}, opts: [ttl: :timer.hours(24)])
+  def get_package_version(name, version) do
+    get("packages/#{name}/releases/#{version}")
+  end
+
   @decorate cacheable(key: {:hexpm_owner, package_name}, opts: [ttl: :timer.hours(24)])
   def get_package_owners(package_name) do
     :httpc.request(

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -108,7 +108,7 @@ defmodule ToolboxWeb.PackageLive do
 
   defp version(name, version) do
     version_data =
-      case Toolbox.Hexpm.get("packages/#{name}/releases/#{version}") do
+      case Toolbox.Hexpm.get_package_version(name, version) do
         {:ok, {{_, 200, _}, _headers, version_data}} ->
           version_data
 


### PR DESCRIPTION
Doing this as an intermediate step while we figure out a proper fix