### PR TITLE
chore remove n+1 query on dependencies for getting the description

### DIFF
--- a/lib/toolbox/package.ex
+++ b/lib/toolbox/package.ex
@@ -4,6 +4,7 @@ defmodule Toolbox.Package do
 
   schema "packages" do
     field :name, :string
+    field :description, :string
 
     has_many :hexpm_snapshots, Toolbox.HexpmSnapshot
     has_many :github_snapshots, Toolbox.GithubSnapshot
@@ -17,7 +18,7 @@ defmodule Toolbox.Package do
   @doc false
   def changeset(package, attrs) do
     package
-    |> cast(attrs, [:name])
+    |> cast(attrs, [:name, :description])
     |> validate_required([:name])
   end
 end

--- a/lib/toolbox/packages.ex
+++ b/lib/toolbox/packages.ex
@@ -71,6 +71,11 @@ defmodule Toolbox.Packages do
     |> Repo.one!()
   end
 
+  def get_packages_by_name(names) do
+    from(p in Package, where: p.name in ^names)
+    |> Repo.all()
+  end
+
   def create_package(attributes \\ %{}) do
     %Package{}
     |> Package.changeset(attributes)

--- a/lib/toolbox/tasks/hexpm.ex
+++ b/lib/toolbox/tasks/hexpm.ex
@@ -62,6 +62,7 @@ defmodule Toolbox.Tasks.Hexpm do
 
   defp create_hexpm_snapshot(package_data) do
     name = package_data["name"]
+    description = package_data["meta"]["description"]
 
     package =
       case Toolbox.Packages.get_package_by_name(name) do
@@ -69,7 +70,7 @@ defmodule Toolbox.Tasks.Hexpm do
           p
 
         _ ->
-          {:ok, p} = Toolbox.Packages.create_package(%{name: name})
+          {:ok, p} = Toolbox.Packages.create_package(%{name: name, description: description})
           p
       end
 

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -121,10 +121,11 @@ defmodule ToolboxWeb.PackageLive do
       |> to_string()
       |> JSON.decode!()
 
-    descriptions = data["requirements"]
-                   |> Enum.map(fn {name, _data} -> name end)
-                   |> Toolbox.Packages.get_packages_by_name()
-                   |> Enum.into(%{}, fn p -> {p.name, p.description} end)
+    descriptions =
+      data["requirements"]
+      |> Enum.map(fn {name, _data} -> name end)
+      |> Toolbox.Packages.get_packages_by_name()
+      |> Enum.into(%{}, fn p -> {p.name, p.description} end)
 
     {optional, required} =
       data["requirements"]

--- a/lib/toolbox_web/live/search_live.html.heex
+++ b/lib/toolbox_web/live/search_live.html.heex
@@ -25,7 +25,7 @@
           </.link>
 
           <div class="mt-2 text-[12px] sm:text-[14px] text-secondary-text">
-            {package.latest_hexpm_snapshot.data["meta"]["description"]}
+            {package.description}
           </div>
 
           <div class="flex items-center mt-3 sm:hidden">

--- a/priv/repo/migrations/20250530143658_add_description_column_to_packages.exs
+++ b/priv/repo/migrations/20250530143658_add_description_column_to_packages.exs
@@ -1,0 +1,9 @@
+defmodule Toolbox.Repo.Migrations.AddDescriptionColumnToPackages do
+  use Ecto.Migration
+
+  def change do
+    alter table(:packages) do
+      add :description, :text
+    end
+  end
+end


### PR DESCRIPTION
* Store description in packages
* Run this query in prod to populate descriptions 
```
UPDATE packages
SET description = hex.data#>>'{meta,description}'
FROM hexpm_snapshots hex
WHERE hex.package_id = packages.id;
```