### PR TITLE
fix: retain user agent in websocket connection

### DIFF
--- a/lib/toolbox_web/endpoint.ex
+++ b/lib/toolbox_web/endpoint.ex
@@ -12,8 +12,8 @@ defmodule ToolboxWeb.Endpoint do
   ]
 
   socket "/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [session: @session_options]],
-    longpoll: [connect_info: [session: @session_options]]
+    websocket: [connect_info: [:user_agent, session: @session_options]],
+    longpoll: [connect_info: [:user_agent, session: @session_options]]
 
   # Serve at "/" the static files from "priv/static" directory.
   #


### PR DESCRIPTION
Pass user agent to WS connection
![image](https://github.com/user-attachments/assets/317488bb-2f3d-49bd-a534-d3bc5671d099)
Related: https://fly.io/phoenix-files/pass-user-agent-info-to-your-liveview/

