### PR TITLE
fix: erratic search result click behaviior in dev

### DIFF
--- a/lib/toolbox_web/components/search_field_component.ex
+++ b/lib/toolbox_web/components/search_field_component.ex
@@ -187,7 +187,9 @@ defmodule ToolboxWeb.SearchFieldComponent do
   end
 
   def handle_event("hide_dropdown", _params, socket) do
-    {:noreply, assign(socket, show_dropdown: false)}
+    # Use a shorter delay to allow click events on dropdown items to fire first
+    Process.send_after(self(), {:hide_dropdown, socket.assigns.myself}, 100)
+    {:noreply, socket}
   end
 
   def handle_event("show_dropdown_if_results", _params, socket) do


### PR DESCRIPTION
This behavior was introduced here: 

https://github.com/mimiquate/elixir_observer/pull/119/files#diff-94cc67170afa99350bc1d4bbab30ccf6f1fe0455069482ddfbe3948777924480L190