### PR TITLE
fix(search) fix layout to align navigation between pages

### DIFF
--- a/lib/toolbox_web/live/search_live.html.heex
+++ b/lib/toolbox_web/live/search_live.html.heex
@@ -1,5 +1,5 @@
 <article
-  class={"pt-3 sm:pt-15 #{if(@results_count == 0, do: "h-full")}"}
+  class={"pt-3 sm:pt-10 #{if(@results_count == 0, do: "h-full")}"}
   {test_attrs(search_results_page: true)}
 >
   <%= if @results_count > 0 do %>


### PR DESCRIPTION
Before
<img width="1915" height="404" alt="image" src="https://github.com/user-attachments/assets/f204531c-c246-41a2-8334-bb44fe561727" />


After
<img width="1906" height="397" alt="image" src="https://github.com/user-attachments/assets/11664076-cc2f-4855-b2dc-9ec2a996af4b" />
