### PR TITLE
fix: owner-chips above search bar visual bug

### DIFF
--- a/lib/toolbox_web/components/package_owners.ex
+++ b/lib/toolbox_web/components/package_owners.ex
@@ -19,13 +19,13 @@ defmodule ToolboxWeb.Components.PackageOwners do
   def render(assigns) do
     ~H"""
     <div
-      class={"mt-3 sm:mt-4 flex flex-wrap gap-2 relative #{@class}"}
+      class={"mt-3 sm:mt-4 flex flex-wrap gap-2  #{@class}"}
       {test_attrs(package_owners_section: true)}
     >
       <.owner_chip :for={owner <- Enum.slice(@owners, 0, 4)} owner={owner} />
 
       <%= if length(@owners) > 4 do %>
-        <div class="relative">
+        <div>
           <div
             class="flex justify-center items-center h-fit py-[2px] pl-[4px] pr-3 rounded-[1.5rem] border border-stroke bg-chip-bg cursor-pointer hover:bg-surface-alt transition-colors"
             phx-click="toggle_owners_popover"


### PR DESCRIPTION
I found a bug where owner-chips were appearing above the search bar results.

## Before
<img width="1432" height="437" alt="image" src="https://github.com/user-attachments/assets/e52a5079-f7cd-4d7f-9335-0854350c307d" />

## After
<img width="1432" height="437" alt="image" src="https://github.com/user-attachments/assets/5779a118-e86b-409a-a90b-861d04857bb6" />
