### PR TITLE
fix: home and package admin page titles

### DIFF
--- a/lib/toolbox_web/components/layouts/root.html.heex
+++ b/lib/toolbox_web/components/layouts/root.html.heex
@@ -6,7 +6,7 @@
     <meta name="csrf-token" content={get_csrf_token()} />
     <link rel="icon" href={~p"/images/favicon.svg"} type="image/svg+xml" />
     <.live_title suffix=" · Elixir Observer">
-      {assigns[:page_title] || "Home"}
+      {assigns[:page_title]}
     </.live_title>
 
     {Application.get_env(:live_debugger, :live_debugger_tags)}

--- a/lib/toolbox_web/live/admin/package_live.ex
+++ b/lib/toolbox_web/live/admin/package_live.ex
@@ -6,7 +6,10 @@ defmodule ToolboxWeb.Admin.PackageLive do
 
     {
       :ok,
-      assign(socket, package: package)
+      assign(socket,
+        package: package,
+        page_title: "#{name} - Admin"
+      )
     }
   end
 end

--- a/lib/toolbox_web/live/home_live.ex
+++ b/lib/toolbox_web/live/home_live.ex
@@ -2,7 +2,7 @@ defmodule ToolboxWeb.HomeLive do
   use ToolboxWeb, :live_view
 
   def mount(_params, _session, socket) do
-    {:ok, socket, layout: {ToolboxWeb.Layouts, :home}}
+    {:ok, assign(socket, page_title: "Home"), layout: {ToolboxWeb.Layouts, :home}}
   end
 
   def handle_info({:hide_dropdown, component_id}, socket) do


### PR DESCRIPTION
## Description 

Page titles were not being set correctly due to missing assignments on both the home page and the package admin page.

## Before

https://github.com/user-attachments/assets/607395c0-f7a3-4dcf-9b1f-4d3aecf54521

## After

https://github.com/user-attachments/assets/1cddee5a-8fca-4051-8766-c98d594f5ee6



