### PR TITLE
feat: Remove split in categories count

### DIFF
--- a/lib/toolbox_web/live/category_index_live.ex
+++ b/lib/toolbox_web/live/category_index_live.ex
@@ -39,7 +39,7 @@ defmodule ToolboxWeb.CategoryIndexLive do
       else
         # Expand category - fetch packages
         category = Enum.find(socket.assigns.categories, &(&1.id == category_id))
-        {packages, _} = Packages.list_packages_from_category(category, 3)
+        packages = Packages.list_packages_from_category(category, 3)
         Map.put(category_packages, category_id, packages)
       end
 

--- a/lib/toolbox_web/live/category_index_live.html.heex
+++ b/lib/toolbox_web/live/category_index_live.html.heex
@@ -30,7 +30,7 @@
           class="text-[10px] flex-none mr-1 px-2 py-[2px] sm:px-5 rounded-full border-[0.5px] sm:text-[16px] text-accent border-accent bg-chip-bg inline h-fit dark:text-text-secondary-button dark:border-stroke"
           {test_attrs(category_count: category.package_count)}
         >
-          {if category.package_count > 50, do: "50+", else: category.package_count} packages
+          {category.package_count} packages
         </span>
       </div>
       <div class="flex items-center justify-between mt-4">

--- a/lib/toolbox_web/live/category_live.ex
+++ b/lib/toolbox_web/live/category_live.ex
@@ -7,7 +7,7 @@ defmodule ToolboxWeb.CategoryLive do
 
   def mount(%{"permalink" => permalink}, _session, socket) do
     category = Packages.get_category_by_permalink!(permalink)
-    {packages, more?} = Packages.list_packages_from_category(category)
+    packages = Packages.list_packages_from_category(category)
 
     {
       :ok,
@@ -15,8 +15,7 @@ defmodule ToolboxWeb.CategoryLive do
         socket,
         page_title: "#{category.name}",
         category: category,
-        packages: packages,
-        more?: more?
+        packages: packages
       )
     }
   end

--- a/lib/toolbox_web/live/category_live.html.heex
+++ b/lib/toolbox_web/live/category_live.html.heex
@@ -17,7 +17,7 @@
 
   <div class="flex justify-between items-center">
     <span class="text-xs mt-1 mr-1 py-1 px-3 sm:px-5 rounded-full border-[0.5px] sm:text-[16px] text-text-secondary-button text-secondary-text border-stroke bg-chip-bg inline-block">
-      {length(@packages)}{if @more?, do: "+", else: ""} packages
+      {length(@packages)} packages
     </span>
   </div>
 

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -63,10 +63,8 @@ defmodule ToolboxWeb.PackageLive do
       update_activity_if_outdated(package, github.sync_at)
     end
 
-    {related_packages, _} = Toolbox.Packages.list_packages_from_category(package.category, 5)
-
     related_packages =
-      related_packages
+      Toolbox.Packages.list_packages_from_category(package.category, 5)
       |> Enum.reject(&(&1.name == name))
       |> Enum.slice(0, 4)
 

--- a/test/toolbox_web/live/category_index_live_test.exs
+++ b/test/toolbox_web/live/category_index_live_test.exs
@@ -1,10 +1,12 @@
 defmodule ToolboxWeb.CategoryIndexLiveTest do
-  use ToolboxWeb.ConnCase, async: true
+  use ToolboxWeb.ConnCase, async: false
   import Phoenix.LiveViewTest
 
   alias Toolbox.{Category, Packages}
 
   setup do
+    Toolbox.Cache.delete_all()
+
     {:ok, bandit_package} =
       Packages.create_package(%{
         name: "bandit",


### PR DESCRIPTION
Show and load all the packages withing a category always in the top 3000 packages

Improve sql queries by caching the top 3000 package ids