### PR TITLE
feat(package-resource): add package resource component and improve clickable areas

### DIFF
--- a/lib/toolbox_web/components/package_resource.ex
+++ b/lib/toolbox_web/components/package_resource.ex
@@ -4,7 +4,7 @@ defmodule ToolboxWeb.Components.PackageResource do
   import ToolboxWeb.Components.Icons.ChevronIcon
 
   attr :href, :string, required: true
-  attr :class, :string, default: nil
+  attr :class, :string, default: ""
   slot :icon
   slot :text
 

--- a/lib/toolbox_web/components/package_resource.ex
+++ b/lib/toolbox_web/components/package_resource.ex
@@ -10,8 +10,8 @@ defmodule ToolboxWeb.Components.PackageResource do
 
   def package_resource(%{href: href} = assigns) when is_binary(href) do
     ~H"""
-    <div class={"flex items-center px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke bg-surface dark:bg-surface-alt #{@class}"}>
-      <.link href={@href} target="_blank" class="flex items-center cursor-pointer">
+    <.link href={@href} target="_blank" class={"flex items-center px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke bg-surface dark:bg-surface-alt #{@class}"}>
+      <div class="flex items-center cursor-pointer">
         <div class="flex-shrink-0">
           {render_slot(@icon)}
         </div>
@@ -20,12 +20,12 @@ defmodule ToolboxWeb.Components.PackageResource do
             {render_slot(@text)}
           </span>
         </div>
-      </.link>
+      </div>
       <div class="flex-1"></div>
-      <.link href={@href} target="_blank" class="flex-shrink-0 cursor-pointer">
+      <div class="flex-shrink-0 cursor-pointer">
         <.chevron_icon class="w-5" />
-      </.link>
-    </div>
+      </div>
+    </.link>
     """
   end
 

--- a/lib/toolbox_web/components/package_resource.ex
+++ b/lib/toolbox_web/components/package_resource.ex
@@ -1,0 +1,48 @@
+defmodule ToolboxWeb.Components.PackageResource do
+  use Phoenix.Component
+
+  import ToolboxWeb.Components.Icons.ChevronIcon
+
+  attr :href, :string, required: true
+  attr :class, :string, default: nil
+  slot :icon
+  slot :text
+
+  def package_resource(%{href: href} = assigns) when is_binary(href) do
+    ~H"""
+    <div class={"flex items-center px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke bg-surface dark:bg-surface-alt #{@class}"}>
+      <.link href={@href} target="_blank" class="flex items-center cursor-pointer">
+        <div class="flex-shrink-0">
+          {render_slot(@icon)}
+        </div>
+        <div class="ml-2">
+          <span class="text-primary-text text-[16px] sm:text-[18px]">
+            {render_slot(@text)}
+          </span>
+        </div>
+      </.link>
+      <div class="flex-1"></div>
+      <.link href={@href} target="_blank" class="flex-shrink-0 cursor-pointer">
+        <.chevron_icon class="w-5" />
+      </.link>
+    </div>
+    """
+  end
+
+  def package_resource(assigns) do
+    ~H"""
+    <div class={"flex items-center px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke bg-surface dark:bg-surface-alt #{@class}"}>
+      <div class="flex items-center flex-1">
+        <div class="flex-shrink-0">
+          {render_slot(@icon)}
+        </div>
+        <div class="ml-2">
+          <span class="text-primary-text text-[16px] sm:text-[18px]">
+            {render_slot(@text)}
+          </span>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -7,6 +7,7 @@ defmodule ToolboxWeb.PackageLive do
   import ToolboxWeb.Components.PackageLink
   import ToolboxWeb.Components.PackageVersionSelector
   import ToolboxWeb.Components.PackageActivity, only: [package_activity: 1]
+  import ToolboxWeb.Components.PackageResource, only: [package_resource: 1]
 
   import ToolboxWeb.Components.Icons.StarIcon
   import ToolboxWeb.Components.Icons.DownloadIcon

--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -242,7 +242,6 @@
 
           <.package_resource
             href={@package.docs_html_url && @package.docs_html_url <> @version.version}
-            class="h-fit order-2"
           >
             <:icon>
               <.doc_icon class="w-5 dark:stroke-secondary-text" />

--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -240,23 +240,19 @@
             <% end %>
           </div>
 
-          <div class="h-fit order-2 flex items-center dark:bg-surface sm:dark:bg-surface-alt px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke">
-            <.doc_icon class="w-5 dark:stroke-secondary-text" />
-            <%= if @package.docs_html_url do %>
-              <.link
-                class="block ml-2 text-primary-text text-[16px] sm:text-[18px]"
-                href={@package.docs_html_url <> @version.version}
-                target="_blank"
-              >
-                Documentation for {@version.version}
-              </.link>
-              <.chevron_icon class="w-5 ml-auto" />
-            <% else %>
-              <span class="block ml-2 text-primary-text text-[16px] sm:text-[18px]">
-                No documentation for {@version.version}
-              </span>
-            <% end %>
-          </div>
+          <.package_resource
+            href={@package.docs_html_url && @package.docs_html_url <> @version.version}
+            class="h-fit order-2"
+          >
+            <:icon>
+              <.doc_icon class="w-5 dark:stroke-secondary-text" />
+            </:icon>
+            <:text>
+              {if @package.docs_html_url,
+                do: "Documentation for #{@version.version}",
+                else: "No documentation for #{@version.version}"}
+            </:text>
+          </.package_resource>
 
           <div class="h-fit dark:bg-surface sm:dark:bg-surface-alt px-3 py-2 sm:px-5 sm:py-3 rounded md:grow border border-stroke sm:col-start-1 sm:row-start-2 sm:row-span-2">
             <div class="flex items-center">
@@ -348,35 +344,28 @@
           </div>
 
           <div class="order-2 sm:mt-0">
-            <div class="h-fit flex items-center bg-surface dark:bg-surface-alt px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke">
-              <.changelog_icon class="w-5 dark:fill-secondary-text" />
-              <%= if @package.changelog_url do %>
-                <.link
-                  class="block ml-2 text-primary-text text-[16px] sm:text-[18px]"
-                  href={@package.changelog_url}
-                  target="_blank"
-                >
-                  Changelog for {@version.version}
-                </.link>
-                <.chevron_icon class="w-5 ml-auto" />
-              <% else %>
-                <span class="block text-primary-text ml-2 text-[16px] sm:text-[18px]">
-                  No changelog for {@version.version}
-                </span>
-              <% end %>
-            </div>
+            <.package_resource href={@package.changelog_url} class="h-fit">
+              <:icon>
+                <.changelog_icon class="w-5 dark:fill-secondary-text" />
+              </:icon>
+              <:text>
+                {if @package.changelog_url,
+                  do: "Changelog for #{@version.version}",
+                  else: "No changelog for #{@version.version}"}
+              </:text>
+            </.package_resource>
 
-            <div class="h-fit flex items-center bg-surface dark:bg-surface-alt px-3 py-2 sm:px-5 sm:py-3 rounded border border-stroke mt-4">
-              <.inspect_icon class="w-5" />
-              <.link
-                class="block ml-2 text-primary-text text-[16px] sm:text-[18px]"
-                href={source_url(@package.name, @version.version)}
-                target="_blank"
-              >
+            <.package_resource
+              href={source_url(@package.name, @version.version)}
+              class="h-fit mt-4"
+            >
+              <:icon>
+                <.inspect_icon class="w-5" />
+              </:icon>
+              <:text>
                 Inspect source for {@version.version}
-              </.link>
-              <.chevron_icon class="w-5 ml-auto" />
-            </div>
+              </:text>
+            </.package_resource>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Encapsulate the logic of the resource item at the right pane below the `Version` header
- Make the whole component clickable

Before:

https://github.com/user-attachments/assets/9a8786df-5a99-4c90-9a7f-69efdd9dc157

After:

https://github.com/user-attachments/assets/74a3870d-885f-4eae-bee6-f8029af0aa89


