### PR TITLE
chore: Refactor latest github snapshot

### DIFF
--- a/lib/toolbox/package.ex
+++ b/lib/toolbox/package.ex
@@ -9,7 +9,6 @@ defmodule Toolbox.Package do
     field :category, Toolbox.Category, source: :category_id
 
     has_many :hexpm_snapshots, Toolbox.HexpmSnapshot
-    has_many :github_snapshots, Toolbox.GithubSnapshot
 
     has_one :latest_hexpm_snapshot, Toolbox.HexpmSnapshot
     has_one :latest_github_snapshot, Toolbox.GithubSnapshot

--- a/lib/toolbox/packages.ex
+++ b/lib/toolbox/packages.ex
@@ -244,13 +244,6 @@ defmodule Toolbox.Packages do
   end
 
   defp latest_github_snaphost_query() do
-    ranking_query =
-      from g in GithubSnapshot,
-        select: %{id: g.id, row_number: over(row_number(), :packages_partition)},
-        windows: [packages_partition: [partition_by: :package_id, order_by: [desc: :id]]]
-
-    from g in GithubSnapshot,
-      join: r in subquery(ranking_query),
-      on: g.id == r.id and r.row_number == 1
+    from(g in GithubSnapshot)
   end
 end

--- a/priv/repo/migrations/20250814011724_modify_github_snapshots_package_id_index.exs
+++ b/priv/repo/migrations/20250814011724_modify_github_snapshots_package_id_index.exs
@@ -1,0 +1,10 @@
+defmodule Toolbox.Repo.Migrations.ModifyGithubSnapshotsPackageIdIndex do
+  use Ecto.Migration
+  @disable_migration_lock true
+  @disable_ddl_transaction true
+
+  def change do
+    drop index(:github_snapshots, ["package_id, id DESC"], concurrently: true)
+    create unique_index(:github_snapshots, :package_id, concurrently: true)
+  end
+end


### PR DESCRIPTION
After this commit: https://github.com/mimiquate/elixir_observer/commit/dbb0fbd8ed41c0457b1350be6a71fd770de001a9

We ended up efectivly with at most one github snapshot per package Add a constrains to validate this and refactor the window function