### PR TITLE
Fix search UI

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -48,27 +48,40 @@ Hooks.SearchHighlight = {
 
   updateHighlight() {
     const text = this.input.value || ''
-    const regex = /^(.*)(\w+):(\S+)(.*)$/
-    const match = text.match(regex)
+    const tagRegex = /(\w+):(\S+)/g
+    const matches = [...text.matchAll(tagRegex)]
 
-    // Get computed text color from input for normal text
-    const inputStyles = window.getComputedStyle(this.input)
-    const textColor = inputStyles.color
+    if (matches.length > 0) {
+      let highlightedText = ''
+      let lastIndex = 0
 
-    if (match) {
-      const [, prefix, key, value, suffix] = match
-      // Show all text, but highlight only the value part
-      this.highlight.innerHTML = `
-        <span class="text-primary-text">
-          ${this.escapeHtml(prefix)}${this.escapeHtml(key)}:
-        </span>
-        <span class="bg-accent/10 text-accent">
-          ${this.escapeHtml(value)}
-        </span>
-        <span class="text-primary-text ml-1">
-          ${this.escapeHtml(suffix)}
-        </span>
-      `
+      matches.forEach((match, index) => {
+        const [fullMatch, key, value] = match
+        const matchStart = match.index
+        const matchEnd = matchStart + fullMatch.length
+        const noFilterText = this.escapeHtml(text.slice(lastIndex, matchStart));
+
+        // Add text before this match
+        if (noFilterText.trim()) {
+          highlightedText += `<span class="text-primary-text ${index > 0 ? "ml-1" : ""}">${noFilterText}</span>`
+        }
+        // Add the key part (not highlighted)
+        highlightedText += `<span class="text-primary-text ${matchStart > 0 ? "ml-1" : ""}">${this.escapeHtml(key)}:</span>`
+        // Add the value part (highlighted)
+        highlightedText += `<span class="bg-accent/10 text-accent">${this.escapeHtml(value)}</span>`
+
+
+        console.log(highlightedText, "af highlightedText")
+
+        lastIndex = matchEnd
+      })
+
+      // Add remaining text after the last match
+      if (lastIndex < text.length) {
+        highlightedText += `<span class="text-primary-text ml-1">${this.escapeHtml(text.slice(lastIndex))}</span>`
+      }
+
+      this.highlight.innerHTML = highlightedText
     } else {
       // Show all text normally when no highlighting needed
       this.highlight.innerHTML = `<span class="text-primary-text">${this.escapeHtml(text)}</span>`

--- a/lib/toolbox_web/components/search_field_component.ex
+++ b/lib/toolbox_web/components/search_field_component.ex
@@ -169,7 +169,7 @@ defmodule ToolboxWeb.SearchFieldComponent do
   end
 
   def handle_event("handle_focus", _params, socket) do
-    do_search(socket, socket.assigns.search_term)
+    do_search(socket, socket.assigns.search_term, %{focused: true})
   end
 
   def handle_event("handle_blur", _params, socket) do
@@ -193,7 +193,7 @@ defmodule ToolboxWeb.SearchFieldComponent do
     {:noreply, assign(socket, show_dropdown: show_dropdown)}
   end
 
-  defp do_search(socket, term) do
+  defp do_search(socket, term, options \\ %{}) do
     term = String.trim(term)
 
     %{clean_term: clean_term} = parsed_search = Toolbox.PackageSearch.parse(term)
@@ -213,7 +213,8 @@ defmodule ToolboxWeb.SearchFieldComponent do
      assign(socket,
        results: results,
        show_dropdown: show_dropdown,
-       search_term: term
+       search_term: term,
+       focused: Map.get(options, :focused, false)
      )}
   end
 end


### PR DESCRIPTION
This PR introduces two fixes:
1. Highlighting all filters present in the search input
2. display search tips when focusing on empty component

<img width="1920" height="965" alt="Screenshot 2025-08-20 at 4 53 15 PM" src="https://github.com/user-attachments/assets/64952580-fbd8-44fd-b46c-232147b4f724" />
<img width="1920" height="968" alt="Screenshot 2025-08-20 at 4 53 23 PM" src="https://github.com/user-attachments/assets/ce522d26-97a3-4d1c-b0d4-3e7f391aca99" />
