### PR TITLE
fix: Handle properly batch insertion from hexpm

### DIFF
--- a/lib/toolbox/packages.ex
+++ b/lib/toolbox/packages.ex
@@ -224,7 +224,16 @@ defmodule Toolbox.Packages do
   def refresh_latest_hexpm_snapshots() do
     Ecto.Adapters.SQL.query!(
       Repo,
-      "REFRESH MATERIALIZED VIEW CONCURRENTLY latest_hexpm_snapshots;"
+      "REFRESH MATERIALIZED VIEW CONCURRENTLY latest_hexpm_snapshots;",
+      [],
+      timeout: 60_000
+    )
+  end
+
+  def skip_refresh_latest_hexpm_snapshots() do
+    Ecto.Adapters.SQL.query!(
+      Repo,
+      "SET LOCAL toolbox.skip_refresh_latest_hexpm_snapshots = 'on'"
     )
   end
 

--- a/lib/toolbox/tasks/hexpm.ex
+++ b/lib/toolbox/tasks/hexpm.ex
@@ -23,7 +23,12 @@ defmodule Toolbox.Tasks.Hexpm do
     |> Stream.each(fn packages_data ->
       packages_data
       |> Jason.decode!()
-      |> Enum.each(&create_hexpm_snapshot/1)
+      |> Enum.each(fn p ->
+        Toolbox.Repo.transact(fn ->
+          Toolbox.Packages.skip_refresh_latest_hexpm_snapshots()
+          create_hexpm_snapshot(p)
+        end)
+      end)
     end)
     |> Stream.run()
   end

--- a/lib/toolbox/workers/hexpm_worker.ex
+++ b/lib/toolbox/workers/hexpm_worker.ex
@@ -5,6 +5,8 @@ defmodule Toolbox.Workers.HexpmWorker do
   def perform(%Oban.Job{meta: %{"cron" => true}}) do
     Toolbox.Tasks.Hexpm.run()
 
+    Toolbox.Packages.refresh_latest_hexpm_snapshots()
+
     :ok
   end
 

--- a/priv/repo/migrations/20250910190511_update_latest_hexpm_trigger.exs
+++ b/priv/repo/migrations/20250910190511_update_latest_hexpm_trigger.exs
@@ -1,0 +1,19 @@
+defmodule Toolbox.Repo.Migrations.UpdateLatestHexpmTrigger do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      CREATE OR REPLACE FUNCTION refresh_latest_hexpm_snapshots()
+      RETURNS TRIGGER LANGUAGE plpgsql
+      AS $$
+      BEGIN
+      IF current_setting('toolbox.skip_refresh_latest_hexpm_snapshots', TRUE) = 'on' THEN
+        RETURN NULL;
+      END IF;
+
+      REFRESH MATERIALIZED VIEW CONCURRENTLY latest_hexpm_snapshots;
+      RETURN NULL;
+      END $$;
+    """
+  end
+end


### PR DESCRIPTION
When we are doing a batch insert of hexpm_snapshot the trigger gets fired with every single insertion. This turn out being a performance issue and making the whole operation a lot slower than needed.

Instead we are skipping the trigger when doing a batch insert and refreshing the materialized view at the end of the process

There are multiple way of disabling the trigger:
One was to alter table and disble the trigger and after the batch insertion enable the trigger again, this is not useful for our case because alter table would lock the table and it will affect all the other users

Other option was to set session replication role, this will disable more checks than needed

We want to be isolate the code that skip the trigger as much as possible, so we end up doing a set local that only applies to that transaction this way we dont need to worry about enabling back because it will after the transaction

For doing that we need to also update the trigger to skip it based on a new custom postgres setting