### PR TITLE
fix: Refresh materialized view takes 100s

### DIFF
--- a/lib/toolbox/packages.ex
+++ b/lib/toolbox/packages.ex
@@ -226,7 +226,7 @@ defmodule Toolbox.Packages do
       Repo,
       "REFRESH MATERIALIZED VIEW CONCURRENTLY latest_hexpm_snapshots;",
       [],
-      timeout: 60_000
+      timeout: 600_000
     )
   end
 


### PR DESCRIPTION
* It will take longer as they are more rows in hexpm_snapshot
* Set a timeout of 10 minutes for now