### PR TITLE
chore: Show oban errors in logs

### DIFF
--- a/lib/toolbox/application.ex
+++ b/lib/toolbox/application.ex
@@ -11,6 +11,13 @@ defmodule Toolbox.Application do
     OpentelemetryPhoenix.setup(adapter: :bandit)
     OpentelemetryEcto.setup([:toolbox, :repo], db_statement: :enabled)
 
+    :telemetry.attach(
+      "oban-logger",
+      [:oban, :job, :exception],
+      &Toolbox.ObanLogger.handle_event/4,
+      []
+    )
+
     Supervisor.start_link(
       [
         Toolbox.Cache,

--- a/lib/toolbox/oban_logger.ex
+++ b/lib/toolbox/oban_logger.ex
@@ -1,0 +1,7 @@
+defmodule Toolbox.ObanLogger do
+  require Logger
+
+  def handle_event([:oban, :job, :exception], _measure, meta, _) do
+    Logger.error("[Oban] #{inspect(meta.error)}")
+  end
+end


### PR DESCRIPTION
https://hexdocs.pm/oban/instrumentation.html#default-logger

<img width="1464" height="459" alt="image" src="https://github.com/user-attachments/assets/a9fd00d5-a681-4434-9862-c2f52d64c638" />

- [ ] Improve the message with the information present in meta
