### PR TITLE
fix: allow to search packages with short names

### DIFF
--- a/lib/toolbox/package_search.ex
+++ b/lib/toolbox/package_search.ex
@@ -17,7 +17,7 @@ defmodule Toolbox.PackageSearch do
   use Nebulex.Caching, cache: Toolbox.Cache
 
   @filter_regex ~r/(?<type>\w+):(?<value>\w+)/
-  @min_search_length 3
+  @min_search_length 2
 
   defstruct [:original_term, :filters, :clean_term]
 
@@ -60,7 +60,7 @@ defmodule Toolbox.PackageSearch do
       iex> PackageSearch.executable?(search)
       false
 
-      iex> search = PackageSearch.parse("ph")
+      iex> search = PackageSearch.parse("p")
       iex> PackageSearch.executable?(search)
       false
   """

--- a/test/toolbox/package_search_test.exs
+++ b/test/toolbox/package_search_test.exs
@@ -151,5 +151,10 @@ defmodule Toolbox.PackageSearchTest do
       # Check actual ordering - nil downloads should come AFTER packages with downloads
       assert [%{name: "high_downloads_pkg"}, %{name: "nil_downloads_pkg"}] = packages
     end
+
+    test "minimum package name length" do
+      refute "c" |> Toolbox.PackageSearch.parse() |> Toolbox.PackageSearch.executable?()
+      assert "ch" |> Toolbox.PackageSearch.parse() |> Toolbox.PackageSearch.executable?()
+    end
   end
 end


### PR DESCRIPTION
Fixes #219

## Description

Allow to search packages with shorter names

## Screenshots

<img width="1292" height="1074" alt="Screenshot 2025-10-10 at 5 25 29 PM" src="https://github.com/user-attachments/assets/40665e4d-d86c-4556-bfa5-d040bfd1f9fd" />

## Testing Instructions

1. Open an `iex -S mix` console
2. Run `Toolbox.Tasks.Hexpm.run(["ch"])`
3. Run `Toolbox.Tasks.SCM.run(["ch"])`
4. Navigate to `/` page
5. Search for the `ch` package

**Expected**

- [ ] The `ch` page appears in the result page.