### PR TITLE
fix(category): Increase Req timeout

### DIFF
--- a/lib/toolbox/tasks/category.ex
+++ b/lib/toolbox/tasks/category.ex
@@ -91,7 +91,8 @@ defmodule Toolbox.Tasks.Category do
           {"x-goog-api-key", "#{api_key()}"},
           {"user-agent", "elixir client"}
         ],
-        json: body
+        json: body,
+        receive_timeout: 120_000
       )
 
     response = response.body


### PR DESCRIPTION
When [changing from httpc to Req](#217 ) we introduced this bug that happens when categorizing multiple packages in one request

* [httpc default timeout is infinity](https://www.erlang.org/doc/apps/inets/httpc.html#request/4)
* [Req defult timout is 15s](https://hexdocs.pm/req/Req.html#new/1)

Increase timeout to 120s