### PR TITLE
bug(related_packages): show the correct number of related packages

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,6 +55,7 @@ config :logger, :default_formatter,
 config :phoenix, :json_library, Jason
 
 config :toolbox, Toolbox.Cache,
+  adapter: Nebulex.Adapters.Local,
   # Max memory size in bytes (e.g., 100MB)
   allocated_memory: 100_000_000
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -53,3 +53,5 @@ config :toolbox, Toolbox.CommunityResources,
       "community_resources",
       "*.json"
     ])
+
+config :toolbox, Toolbox.Cache, adapter: Nebulex.Adapters.Nil

--- a/lib/toolbox/cache.ex
+++ b/lib/toolbox/cache.ex
@@ -1,5 +1,5 @@
 defmodule Toolbox.Cache do
   use Nebulex.Cache,
     otp_app: :toolbox,
-    adapter: Nebulex.Adapters.Local
+    adapter: Application.compile_env!(:toolbox, [__MODULE__, :adapter])
 end

--- a/lib/toolbox/packages.ex
+++ b/lib/toolbox/packages.ex
@@ -100,6 +100,8 @@ defmodule Toolbox.Packages do
     |> Map.new()
   end
 
+  def category_count(nil), do: 0
+
   def category_count(category) do
     from(p in Package,
       where: p.id in ^top_3000_packages_ids(),

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -66,16 +66,12 @@ defmodule ToolboxWeb.PackageLive do
     end
 
     related_packages =
-      Toolbox.Packages.list_packages_from_category(package.category, 5)
+      package.category
+      |> Toolbox.Packages.list_packages_from_category(5)
       |> Enum.reject(&(&1.name == name))
       |> Enum.slice(0, 4)
 
-    related_packages_count =
-      if package.category do
-        Toolbox.Packages.category_count(package.category)
-      else
-        0
-      end
+    related_packages_count = Toolbox.Packages.category_count(package.category) - 1
 
     community_resources =
       Toolbox.Packages.community_resources_for(package)

--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -439,7 +439,7 @@
   </section>
 
   <%= if Enum.any?(@related_packages) do %>
-    <section class="sm:mt-8">
+    <section class="sm:mt-8" {test_attrs(related_packages_section: true)}>
       <div class="flex flex-wrap items-center mt-8 mb-3 sm:mb-8">
         <div class="flex items-center justify-between w-full">
           <h2 class="text-[20px] text-primary-text sm:text-[32px] font-semibold">
@@ -456,8 +456,11 @@
           </.link>
         </div>
 
-        <span class="text-[12px] flex-none mt-2 px-2 py-[2px] sm:px-5 rounded-full border-[0.5px] sm:text-[16px] text-accent border-accent bg-chip-bg inline dark:text-text-secondary-button dark:border-stroke">
-          {@related_packages_count} packages
+        <span
+          class="text-[12px] flex-none mt-2 px-2 py-[2px] sm:px-5 rounded-full border-[0.5px] sm:text-[16px] text-accent border-accent bg-chip-bg inline dark:text-text-secondary-button dark:border-stroke"
+          {test_attrs(related_packages_count: @related_packages_count)}
+        >
+          {@related_packages_count} {ngettext("package", "packages", @related_packages_count)}
         </span>
       </div>
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -34,6 +34,7 @@ defmodule ToolboxWeb.ConnCase do
 
   setup tags do
     Toolbox.DataCase.setup_sandbox(tags)
+
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 
@@ -48,5 +49,12 @@ defmodule ToolboxWeb.ConnCase do
       (name
        |> to_string()
        |> String.replace("_", "-")) <> "]"
+  end
+
+  def data_test_attr(name, value) do
+    "[data-test-" <>
+      (name
+       |> to_string()
+       |> String.replace("_", "-")) <> "=\"#{value}\"]"
   end
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -30,6 +30,7 @@ defmodule Toolbox.DataCase do
 
   setup tags do
     Toolbox.DataCase.setup_sandbox(tags)
+
     :ok
   end
 

--- a/test/toolbox_web/live/category_index_live_test.exs
+++ b/test/toolbox_web/live/category_index_live_test.exs
@@ -5,8 +5,6 @@ defmodule ToolboxWeb.CategoryIndexLiveTest do
   alias Toolbox.{Category, Packages}
 
   setup do
-    Toolbox.Cache.delete_all()
-
     {:ok, bandit_package} =
       Packages.create_package(%{
         name: "bandit",

--- a/test/toolbox_web/live/category_live_test.exs
+++ b/test/toolbox_web/live/category_live_test.exs
@@ -2,64 +2,35 @@ defmodule ToolboxWeb.CategoryLiveTest do
   use ToolboxWeb.ConnCase, async: true
   import Phoenix.LiveViewTest
 
-  alias Toolbox.{Category, Packages}
+  alias Toolbox.Category
 
   setup do
     category = Category.find_by_name("HTTP Server")
 
-    {:ok, bandit_package} =
-      Packages.create_package(%{
-        name: "bandit",
-        description: "A pure Elixir HTTP server",
-        category: category
-      })
-
-    {:ok, cowboy_package} =
-      Packages.create_package(%{
-        name: "cowboy",
-        description: "Small, fast, modular HTTP server",
-        category: category
-      })
-
-    {:ok, _} =
-      Packages.create_hexpm_snapshot(%{
-        package_id: bandit_package.id,
-        data: %{
-          "meta" => %{"description" => "A pure Elixir HTTP server"},
-          "downloads" => %{"recent" => 1000},
-          "latest_stable_version" => "1.0.0"
-        }
-      })
-
-    {:ok, _} =
-      Packages.create_hexpm_snapshot(%{
-        package_id: cowboy_package.id,
-        data: %{
-          "meta" => %{"description" => "Small, fast, modular HTTP server"},
-          "downloads" => %{"recent" => 2000},
-          "latest_stable_version" => "2.0.0"
-        }
-      })
+    {:ok, package1} = create(:package, category: category)
+    {:ok, package2} = create(:package, category: category)
+    {:ok, _} = create(:hexpm_snapshot, package_id: package1.id)
+    {:ok, _} = create(:hexpm_snapshot, package_id: package2.id)
 
     %{
       category: category,
-      bandit_package: bandit_package,
-      cowboy_package: cowboy_package
+      package1: package1,
+      package2: package2
     }
   end
 
   describe "CategoryLive page rendering" do
     test "renders category page with packages", %{
       category: category,
-      bandit_package: bandit_package,
-      cowboy_package: cowboy_package
+      package1: package1,
+      package2: package2
     } do
       {:ok, view, html} = live(build_conn(), "/categories/#{category.permalink}")
 
       assert page_title(view) =~ category.name
       assert html =~ category.name
-      assert has_element?(view, "[data-test-package-link='#{bandit_package.name}']")
-      assert has_element?(view, "[data-test-package-link='#{cowboy_package.name}']")
+      assert has_element?(view, data_test_attr(:package_link, package1.name))
+      assert has_element?(view, data_test_attr(:package_link, package2.name))
     end
   end
 end


### PR DESCRIPTION
## Description

- Do not include the current package in the count of related packages in package page.
- Empty memory cache in tests

## Testing Instructions

1. Open an iex -S mix console
2. Run Toolbox.Tasks.Hexpm.run(["bandit", "tower"])
3. Run Toolbox.Tasks.SCM.run(["bandit", "tower"])
4. Assign the same category to `bandit`, `tower`

**Test Case 1** Visit the package bandit and check the related package badge shows "1 package"
**Test Case 2** Add a category to three package and check the related package badge shows a plural message "2 packages" for example

## Screenshots

<img width="808" height="357" alt="Screenshot 2025-10-24 at 1 26 28 PM" src="https://github.com/user-attachments/assets/3f708cc7-3e5d-4715-87c5-82b76ba68929" />

<img width="823" height="248" alt="Screenshot 2025-10-24 at 1 26 05 PM" src="https://github.com/user-attachments/assets/e012e37d-f8bc-4803-8062-4a9d7c09bcff" />
