### PR TITLE
feat: add community resources for several packages

### DIFF
--- a/priv/community_resources/bandit.json
+++ b/priv/community_resources/bandit.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "podcast",
+      "title": "Thinking Elixir 128 — Speedy like a Bandit",
+      "description": "Interview with Bandit’s author on design goals, Phoenix compatibility, and performance vs Cowboy.",
+      "url": "https://podcast.thinkingelixir.com/128"
+    },
+    {
+      "type": "video",
+      "title": "Phoenix Beyond Cowboy — Mat Trudel (ElixirConf EU 2023)",
+      "description": "Talk about Phoenix’s support for alternative web servers and how Bandit fits in.",
+      "url": "https://www.youtube.com/watch?v=usKLrYl4zlY"
+    },
+    {
+      "type": "article",
+      "title": "Bandit — pure Elixir HTTP server (community announcement)",
+      "description": "Elixir Forum post with performance notes, HTTP/1.x and HTTP/2 comparisons, and project background.",
+      "url": "https://elixirforum.com/t/bandit-a-pure-elixir-http-server-for-plug-websock-applications/59146"
+    },
+    {
+      "type": "article",
+      "title": "Perfect Elixir: Adding Bandit to a basic Elixir web app",
+      "description": "Practical snippet-driven guide showing how to run a Plug app on Bandit and wire it into supervision.",
+      "url": "https://dev.to/jonlauridsen/perfect-elixir-foundations-of-a-web-app-95l"
+    },
+    {
+      "type": "article",
+      "title": "Delivering social change with Elixir at Change.org",
+      "description": "Case study mentioning a Bandit-powered Phoenix API as part of Change.org’s stack.",
+      "url": "https://elixir-lang.org/blog/2020/10/27/delivering-social-change-with-elixir-at-change.org/"
+    }
+  ]
+}

--- a/priv/community_resources/bunt.json
+++ b/priv/community_resources/bunt.json
@@ -1,0 +1,22 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Unable to colorize escript text output",
+      "description": "Elixir Forum discussion about using Bunt for CLI colors and gotchas in escripts.",
+      "url": "https://elixirforum.com/t/unable-to-colorize-escript-text-output/2563"
+    },
+    {
+      "type": "article",
+      "title": "How to colorize JSON on terminal?",
+      "description": "Community thread exploring approaches to colorized terminal output in Elixir projects.",
+      "url": "https://elixirforum.com/t/how-to-colorize-json-on-terminal/12448"
+    },
+    {
+      "type": "article",
+      "title": "Cool CLIs in Elixir (Part 2) with IO.ANSI",
+      "description": "Tutorial on coloring terminal output in Elixir CLIs; useful context alongside Bunt.",
+      "url": "https://dennisbeatty.com/cool-clis-in-elixir-part-2-with-io-ansi/"
+    }
+  ]
+}

--- a/priv/community_resources/cachex.json
+++ b/priv/community_resources/cachex.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Powerful Caching in Elixir with Cachex",
+      "description": "Hands-on article showing Cachex patterns to speed up applications and avoid redundant work.",
+      "url": "https://blog.appsignal.com/2024/03/05/powerful-caching-in-elixir-with-cachex.html"
+    },
+    {
+      "type": "video",
+      "title": "ElixirCasts #79 — Caching with Cachex",
+      "description": "Short screencast demonstrating how to add and use Cachex in an Elixir app.",
+      "url": "https://elixircasts.io/caching-with-cachex"
+    },
+    {
+      "type": "article",
+      "title": "Cachex with Phoenix",
+      "description": "Step-by-step blog post wiring Cachex into a Phoenix project for expensive queries.",
+      "url": "https://www.alenm.com/code/phoenix-cachex"
+    },
+    {
+      "type": "article",
+      "title": "Use caching to speed up data loading in Phoenix LiveView",
+      "description": "Quick tip showing how to use Cachex to avoid double database hits during LiveView mount.",
+      "url": "https://fullstackphoenix.com/quick_tips/liveview-caching"
+    },
+    {
+      "type": "article",
+      "title": "Caching in Phoenix/Elixir with Cachex",
+      "description": "A concise walkthrough for setting up Cachex and organizing a cache service in Phoenix.",
+      "url": "https://alvinrapada.medium.com/caching-in-phoenix-elixir-with-cachex-1ca2c9442618"
+    }
+  ]
+}

--- a/priv/community_resources/ecto.json
+++ b/priv/community_resources/ecto.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Ecto: An Introduction to Elixir’s Database Toolkit",
+      "description": "Beginner guide covering repos, schemas, migrations, and CRUD.",
+      "url": "https://serokell.io/blog/ecto-guide-for-beginners"
+    },
+    {
+      "type": "article",
+      "title": "Ecto for Elixir: A Beginner’s Guide to Database Interactions",
+      "description": "Recent walkthrough of core Ecto concepts with examples.",
+      "url": "https://medium.com/%40actor-swe/ecto-for-elixir-a-beginners-guide-to-database-interactions-64190162664b"
+    },
+    {
+      "type": "video",
+      "title": "Wired up! Using Ecto without schemas",
+      "description": "Conference talk exploring Ecto usage without schemas and when it fits.",
+      "url": "https://www.youtube.com/watch?v=YJp6r6IXP6U"
+    },
+    {
+      "type": "article",
+      "title": "Elixir Without Ecto",
+      "description": "Opinionated piece exploring direct SQL with Postgrex vs using Ecto.",
+      "url": "https://www.openmymind.net/Elixir-Without-Ecto/"
+    },
+    {
+      "type": "article",
+      "title": "Getting started with Ecto in Phoenix",
+      "description": "Step-by-step tutorial integrating Ecto in a Phoenix project.",
+      "url": "https://blog.logrocket.com/getting-started-ecto-phoenix/"
+    }
+  ]
+}

--- a/priv/community_resources/hackney.json
+++ b/priv/community_resources/hackney.json
@@ -1,0 +1,22 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "How to download large file in Elixir with :hackney",
+      "description": "Walkthrough of streaming a large CSV from S3 using the :hackney Erlang HTTP client.",
+      "url": "https://dev.to/onpointvn/download-stream-large-file-with-hackney-in-elixir-539m"
+    },
+    {
+      "type": "article",
+      "title": "Is httpc considered bad? Why shouldn’t I use it?",
+      "description": "Forum thread comparing Erlang HTTP clients and why projects often choose :hackney.",
+      "url": "https://erlangforums.com/t/is-httpc-considered-bad-why-shouldn-t-i-use-it/3505"
+    },
+    {
+      "type": "article",
+      "title": "Elixir: How to send body parameters using hackney",
+      "description": "StackOverflow Q&A showing correct request body handling with :hackney.",
+      "url": "https://stackoverflow.com/questions/59739588/elixir-how-to-send-body-parameters-using-hackney"
+    }
+  ]
+}

--- a/priv/community_resources/hammer.json
+++ b/priv/community_resources/hammer.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Elixir/Phoenix Security: Rate Limits for Authentication with Hammer",
+      "description": "Practical guide to adding authentication rate limits in Phoenix with Hammer, including risks and configuration.",
+      "url": "https://paraxial.io/blog/auth-rate-limit"
+    },
+    {
+      "type": "video",
+      "title": "ElixirCasts #172 — Rate-limiting a Phoenix API with Hammer",
+      "description": "Screencast implementing per-user API rate limiting using Hammer and returning 429 responses.",
+      "url": "https://elixircasts.io/rate-limiting-a-phoenix-api-with-hammer"
+    },
+    {
+      "type": "article",
+      "title": "Rate Limits Phoenix",
+      "description": "Blog post showing how to add a Hammer-based rate limiter plug to a Phoenix API pipeline.",
+      "url": "https://dev.to/vkxni/rate-limits-phoenix-dmd"
+    },
+    {
+      "type": "article",
+      "title": "How to make rate limiting in Phoenix 1.7? (community tips)",
+      "description": "Elixir Forum thread discussing Hammer backends (ETS/Redis) and approaches to per-role limits.",
+      "url": "https://elixirforum.com/t/how-to-make-rate-limiting-in-phoenix-1-7/65381"
+    },
+    {
+      "type": "article",
+      "title": "Building a Distributed Rate Limiter in Elixir with HashRing",
+      "description": "AppSignal article that includes examples wrapping Hammer for clustered rate limiting patterns.",
+      "url": "https://blog.appsignal.com/2025/02/04/building-a-distributed-rate-limiter-in-elixir-with-hashring.html"
+    }
+  ]
+}

--- a/priv/community_resources/jason.json
+++ b/priv/community_resources/jason.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Serialize and Deserialize JSON in Elixir",
+      "description": "Step-by-step guide on encoding/decoding JSON with Jason, pitfalls, and custom encoders/decoders.",
+      "url": "[https://ssojet.com/serialize-and-deserialize/serialize-and-deserialize-json-in-elixir/](https://ssojet.com/serialize-and-deserialize/serialize-and-deserialize-json-in-elixir/)"
+    },
+    {
+      "type": "article",
+      "title": "Custom JSON encoding for structs in Elixir with Jason",
+      "description": "How to implement custom Jason.Encoder for your structs, with examples and rationale.",
+      "url": "[https://www.chriis.dev/opinion/how-to-custom-jason-encoding-for-structs-in-elixir](https://www.chriis.dev/opinion/how-to-custom-jason-encoding-for-structs-in-elixir)"
+    },
+    {
+      "type": "article",
+      "title": "Jason: a blazing fast JSON parser and generator in pure Elixir",
+      "description": "Community discussion and benchmarks around Jason vs other JSON libraries.",
+      "url": "[https://elixirforum.com/t/jason-a-blazing-fast-json-parser-and-generator-in-pure-elixir/11030](https://elixirforum.com/t/jason-a-blazing-fast-json-parser-and-generator-in-pure-elixir/11030)"
+    },
+    {
+      "type": "article",
+      "title": "How to have custom encoding for struct using Jason?",
+      "description": "StackOverflow thread showing patterns for custom encoding and common gotchas.",
+      "url": "[https://stackoverflow.com/questions/71436312/how-to-have-custom-enconding-for-struct-using-jason](https://stackoverflow.com/questions/71436312/how-to-have-custom-enconding-for-struct-using-jason)"
+    }
+  ]
+}

--- a/priv/community_resources/jose.json
+++ b/priv/community_resources/jose.json
@@ -1,0 +1,22 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Encrypting a JSON Web Token in Erlang, using JOSE",
+      "description": "Step-by-step JOSE example for signing and encrypting JWTs (Erlang, applicable to Elixir).",
+      "url": "https://blog.differentpla.net/blog/2023/02/13/jwt-encryption-jose/"
+    },
+    {
+      "type": "article",
+      "title": "Elixir and Phoenix Decoded: Configuring Guardian and GuardianDB",
+      "description": "Tutorial that includes generating Guardian secret keys using JOSE.",
+      "url": "https://medium.com/%40erickipnis/elixir-and-phoenix-decoded-configuring-guardian-and-guardiandb-b49f68adb98b"
+    },
+    {
+      "type": "article",
+      "title": "Using Joken for JWE? (discussion referencing erlang-jose)",
+      "description": "Elixir Forum thread on when to use JOSE directly for JWE versus higher-level JWT libraries.",
+      "url": "https://elixirforum.com/t/using-joken-for-jwe/41170"
+    }
+  ]
+}

--- a/priv/community_resources/nebulex.json
+++ b/priv/community_resources/nebulex.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "type": "podcast",
+      "title": "Thinking Elixir 124 — Caching Things Anywhere with Nebulex",
+      "description": "Conversation with Nebulex’s author on decorator-style caching, adapters, and use cases.",
+      "url": "https://podcast.thinkingelixir.com/124"
+    },
+    {
+      "type": "podcast",
+      "title": "EMx 235 — Caching Complexity: The Evolution of Nebulex",
+      "description": "Elixir Mix episode exploring algorithms, eviction policies, and Nebulex’s architecture.",
+      "url": "https://topenddevs.com/podcasts/elixir-mix/episodes/caching-complexity-the-evolution-of-nebulex-in-elixir-applications-emx-235"
+    },
+    {
+      "type": "article",
+      "title": "How to Cache Locally in Elixir with Nebulex",
+      "description": "AppSignal guide introducing Nebulex and showing local cache set-up and usage.",
+      "url": "https://blog.appsignal.com/2022/12/13/how-to-cache-locally-in-elixir-with-nebulex.html"
+    },
+    {
+      "type": "podcast",
+      "title": "Caching Complexity: The Evolution of Nebulex (Spotify)",
+      "description": "Audio stream of the Nebulex discussion covering strategies and trade-offs.",
+      "url": "https://open.spotify.com/episode/2b9Gvg1wMXJCxrf6ohumy6"
+    }
+  ]
+}

--- a/priv/community_resources/nimble_parsec.json
+++ b/priv/community_resources/nimble_parsec.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "type": "video",
+      "title": "Craft your domain-specific query language with NimbleParsec and Ecto",
+      "description": "Talk demonstrating building a DSL parser with NimbleParsec and turning it into an AST.",
+      "url": "https://www.youtube.com/watch?v=T4komUAGMp8"
+    },
+    {
+      "type": "article",
+      "title": "Understanding NimbleParsec in Elixir",
+      "description": "Recent overview of how NimbleParsec works and when to use parser combinators.",
+      "url": "https://medium.com/beamworld/understanding-nimbleparsec-in-elixir-building-powerful-parsers-with-ease-808c554e4f01"
+    },
+    {
+      "type": "article",
+      "title": "Parser Combinators in Elixir: Taming Semi-Structured Text",
+      "description": "Intro tutorial using NimbleParsec to parse and normalize text inputs.",
+      "url": "https://blog.appsignal.com/2022/10/18/parser-combinators-in-elixir-taming-semi-structured-text.html"
+    },
+    {
+      "type": "article",
+      "title": "Writing a boolean expression parser in Elixir using NimbleParsec",
+      "description": "Step-by-step tutorial building a boolean expression parser.",
+      "url": "https://stefan.lapers.be/posts/elixir-writing-an-expression-parser-with-nimble-parsec/"
+    }
+  ]
+}

--- a/priv/community_resources/oban.json
+++ b/priv/community_resources/oban.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "podcast",
+      "title": "Thinking Elixir 163 — Job Queues using Oban with Parker Selbert",
+      "description": "Interview with Oban’s creator covering design, extensions (Web/Pro), and real-world scale.",
+      "url": "https://podcast.thinkingelixir.com/163"
+    },
+    {
+      "type": "video",
+      "title": "Scaling Oban Applications — ElixirConf EU 2024",
+      "description": "Conference talk on scaling strategies, plugins, backoff, and operational considerations with Oban.",
+      "url": "https://www.youtube.com/watch?v=1v52vTYlblM"
+    },
+    {
+      "type": "article",
+      "title": "Parallel Request Processing with Elixir and Oban",
+      "description": "DockYard tutorial using Oban jobs to parallelize HTTP requests with backoff and rate limiting.",
+      "url": "https://dockyard.com/blog/2024/03/26/parallel-request-processing-with-elixir-and-oban"
+    },
+    {
+      "type": "video",
+      "title": "Oban Beyond the Basics — Joseph Yiasemides",
+      "description": "Meetup talk diving into advanced Oban patterns beyond initial setup.",
+      "url": "https://www.youtube.com/watch?v=jZ237UL7Cq8"
+    },
+    {
+      "type": "article",
+      "title": "How to set up recurring jobs with Oban in Elixir",
+      "description": "Tutorial creating daily scheduled jobs (e.g., digest emails) with Oban and Bamboo.",
+      "url": "https://fullstackphoenix.com/tutorials/how-to-setup-recurring-jobs-with-oban-in-elixir"
+    }
+  ]
+}

--- a/priv/community_resources/phoenix.json
+++ b/priv/community_resources/phoenix.json
@@ -1,0 +1,22 @@
+{
+  "resources": [
+    {
+      "type": "video",
+      "title": "Phoenix Framework REST API Crash Course",
+      "description": "Beginner-friendly crash course to building APIs with Phoenix.",
+      "url": "https://www.youtube.com/watch?v=9xaN44PNxps"
+    },
+    {
+      "type": "video",
+      "title": "Chris McCord on Phoenix 1.8 and AI-Powered Development",
+      "description": "Conversation with Phoenix’s creator on 1.8 updates and DX topics.",
+      "url": "https://www.youtube.com/watch?v=9HePXo5K328"
+    },
+    {
+      "type": "podcast",
+      "title": "Thinking Elixir 259: Chris McCord on phoenix.new",
+      "description": "Interview covering the phoenix.new service and developer onboarding themes.",
+      "url": "https://elixirforum.com/t/thinking-elixir-259-chris-mccord-on-phoenix-new/71505"
+    }
+  ]
+}

--- a/priv/community_resources/plug.json
+++ b/priv/community_resources/plug.json
@@ -1,0 +1,22 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "A deeper dive in Elixir’s Plug",
+      "description": "Explains the Plug specification, pipelines, and how Plug integrates with servers like Cowboy.",
+      "url": "https://ieftimov.com/posts/a-deeper-dive-in-elixir-plug/"
+    },
+    {
+      "type": "article",
+      "title": "Building Blocks of Elixir: Plug",
+      "description": "Beginner-friendly intro to Plug with a small project to learn the basics.",
+      "url": "https://www.viget.com/articles/building-blocks-of-elixir-plug/"
+    },
+    {
+      "type": "article",
+      "title": "Elixir Plug unveiled",
+      "description": "Conceptual look under the hood at how Plug works and compiles.",
+      "url": "https://medium.com/%40kansi/elixir-plug-unveiled-bf354e364641"
+    }
+  ]
+}

--- a/priv/community_resources/poison.json
+++ b/priv/community_resources/poison.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Poison v6.0.0 released (performance discussion)",
+      "description": "Community thread noting significant parsing and encoding performance improvements.",
+      "url": "https://www.reddit.com/r/elixir/comments/1dbrl4b/poison_v600_released/"
+    },
+    {
+      "type": "article",
+      "title": "Poison vs Jason (community comparison)",
+      "description": "Community comparison page tracking popularity, activity, and library highlights.",
+      "url": "https://elixir.libhunt.com/compare-poison-vs-jason"
+    }
+  ]
+}

--- a/priv/community_resources/postgrex.json
+++ b/priv/community_resources/postgrex.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Listen to Database Changes with Postgres Triggers and Elixir",
+      "description": "Guide to using LISTEN/NOTIFY with Postgrex and Phoenix for reactive apps.",
+      "url": "https://peterullrich.com/listen-to-database-changes-with-postgres-triggers-and-elixir"
+    },
+    {
+      "type": "article",
+      "title": "CDC with Postgrex & Elixir",
+      "description": "Change Data Capture using Postgres logical replication from Elixir.",
+      "url": "https://simonth.dev/posts/cdc-with-elixir/"
+    },
+    {
+      "type": "podcast",
+      "title": "Postgres PubSub and Elixir",
+      "description": "Podcast episode on using Postgres notifications through the postgrex library.",
+      "url": "https://podcast.thinkingelixir.com/33"
+    },
+    {
+      "type": "article",
+      "title": "Top Ten Tips for LISTEN/NOTIFY with Phoenix LiveView",
+      "description": "Practical patterns for wiring Postgrex.Notifications into LiveView apps.",
+      "url": "https://hexshift.medium.com/top-ten-tips-for-using-postgresql-listen-notify-with-phoenix-liveview-53c134a15931"
+    }
+  ]
+}

--- a/priv/community_resources/ranch.json
+++ b/priv/community_resources/ranch.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Cowboy architecture and execution flow",
+      "description": "Overview of Cowboy built on Ranch and how they power many Erlang/Elixir web apps.",
+      "url": "https://medium.com/%40scarfacedeb/cowboy-architecture-and-execution-flow-df7227a6573"
+    },
+    {
+      "type": "article",
+      "title": "Survey of Cowboy Webserver Performance - Part 1",
+      "description": "Explains Cowboy’s architecture and how Ranch serves as its TCP acceptor pool.",
+      "url": "https://stressgrid.com/blog/cowboy_performance/"
+    },
+    {
+      "type": "article",
+      "title": "Achieving 100k connections per second with Elixir",
+      "description": "Benchmark write-up featuring Ranch as the socket acceptor pool at the heart of Cowboy.",
+      "url": "https://stressgrid.com/blog/100k_cps_with_elixir/"
+    },
+    {
+      "type": "article",
+      "title": "Visualizing Parallel Requests in Elixir",
+      "description": "Shows how Cowboy uses Ranch and how Plug fits into the request pipeline.",
+      "url": "https://www.codemancers.com/blog/2016-01-15-visualizing-parallel-requests-in-elixir"
+    }
+  ]
+}

--- a/priv/community_resources/req.json
+++ b/priv/community_resources/req.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "video",
+      "title": "Building API Clients with Req — Wojtek Mach (ElixirConf EU)",
+      "description": "Conference talk showing how to design and build robust HTTP API clients in Elixir using Req, with a focus on extensibility and composable steps.",
+      "url": "https://www.youtube.com/watch?v=AexE5JKpNvA"
+    },
+    {
+      "type": "video",
+      "title": "Req — a batteries-included HTTP client for Elixir (ElixirConf 2023)",
+      "description": "Overview of Req’s features like retries, redirects, decompression, and the steps pipeline, with practical examples.",
+      "url": "https://www.youtube.com/watch?v=owz2QacFuoQ"
+    },
+    {
+      "type": "article",
+      "title": "Req API Client Testing",
+      "description": "Dashbit post walking through approaches to testing third-party API integrations built with Req, including helpers and patterns.",
+      "url": "https://dashbit.co/blog/req-api-client-testing"
+    },
+    {
+      "type": "article",
+      "title": "SDKs with Req: S3",
+      "description": "How to create focused SDK-style clients on top of Req, illustrated with S3 operations and a Req plugin.",
+      "url": "https://dashbit.co/blog/sdks-with-req-s3"
+    },
+    {
+      "type": "article",
+      "title": "Tutorial on File Uploads with Req and Multipart Libraries in Elixir",
+      "description": "Guide showing how to perform multipart file uploads with Req by pairing it with a multipart encoder, using a Whisper API example.",
+      "url": "https://elixirmerge.com/p/tutorial-on-file-uploads-with-req-and-multipart-libraries-in-elixir"
+    }
+  ]
+}

--- a/priv/community_resources/tailwind.json
+++ b/priv/community_resources/tailwind.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Using Tailwind CSS in Phoenix 1.7",
+      "description": "Pragmatic Studio walkthrough of Phoenix 1.7’s built-in Tailwind setup and how to customize it.",
+      "url": "https://pragmaticstudio.com/tutorials/using-tailwind-css-in-phoenix"
+    },
+    {
+      "type": "article",
+      "title": "Tailwind Standalone for Phoenix",
+      "description": "Fly.io Phoenix Files article explaining the standalone Tailwind CLI and no-Node setup.",
+      "url": "https://fly.io/phoenix-files/tailwind-standalone/"
+    },
+    {
+      "type": "video",
+      "title": "Gustavo Oliveira on Tailwind in Phoenix (All Things Elixir)",
+      "description": "Video discussion on getting started with Tailwind in Phoenix projects and common tips.",
+      "url": "https://www.youtube.com/watch?v=a7Oj3lXk_sw"
+    },
+    {
+      "type": "article",
+      "title": "How to Build Visually Cohesive Real-Time Interfaces in Phoenix LiveView Using Tailwind CSS",
+      "description": "Practical design and implementation tips for pairing LiveView with Tailwind for polished UIs.",
+      "url": "https://dev.to/hexshift/how-to-build-visually-cohesive-real-time-interfaces-in-phoenix-liveview-using-tailwind-css-3m5h"
+    },
+    {
+      "type": "article",
+      "title": "Get started with Tailwind in Phoenix",
+      "description": "Step-by-step setup guide (updated for Tailwind 3 and Phoenix 1.6.x) with examples.",
+      "url": "https://fullstackphoenix.com/tutorials/get-started-with-tailwind-in-phoenix"
+    }
+  ]
+}

--- a/priv/community_resources/telemetry.json
+++ b/priv/community_resources/telemetry.json
@@ -1,0 +1,28 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Introduction to Telemetry in Elixir",
+      "description": "Hands-on introduction to what Telemetry is and how to emit and handle events.",
+      "url": "https://blog.miguelcoba.com/introduction-to-telemetry-in-elixir"
+    },
+    {
+      "type": "article",
+      "title": "Elixir Telemetry: Metrics and Reporters",
+      "description": "Practical guide to choosing and capturing metrics with Telemetry.Metrics.",
+      "url": "https://samuelmullen.com/articles/elixir-telemetry-metrics-and-reporters"
+    },
+    {
+      "type": "article",
+      "title": "Out-of-the-box Elixir telemetry with Phoenix",
+      "description": "Shows Phoenix’s built-in Telemetry events and how to hook them up for monitoring.",
+      "url": "https://www.honeybadger.io/blog/phoenix-telemetry/"
+    },
+    {
+      "type": "podcast",
+      "title": "Operational Elixir: Observing the Midsize Madness",
+      "description": "Podcast discussion on observability patterns and tools in Elixir systems.",
+      "url": "https://podcast.thinkingelixir.com/193"
+    }
+  ]
+}

--- a/priv/community_resources/tidewave.json
+++ b/priv/community_resources/tidewave.json
@@ -1,0 +1,34 @@
+{
+  "resources": [
+    {
+      "type": "article",
+      "title": "Tidewave Web: in-browser coding agent for Rails and Phoenix",
+      "description": "Announcement detailing Tidewave Web’s model-aware, in-browser agent that integrates with Phoenix and Rails for full-stack changes.",
+      "url": "https://tidewave.ai/blog/tidewave-web-phoenix-rails"
+    },
+    {
+      "type": "podcast",
+      "title": "Thinking Elixir 267 — Dive into Tidewave Web with José Valim",
+      "description": "Interview and deep dive into Tidewave’s goals, architecture, and developer workflow inside Phoenix.",
+      "url": "https://podcast.thinkingelixir.com/267"
+    },
+    {
+      "type": "video",
+      "title": "Thinking Elixir 267 — Dive into Tidewave Web (YouTube)",
+      "description": "Video version of the episode covering Tidewave’s in-browser agent and Phoenix integration.",
+      "url": "https://www.youtube.com/watch?v=pKlwt73XzmM"
+    },
+    {
+      "type": "article",
+      "title": "The path to Tidewave: beyond code intelligence",
+      "description": "Dashbit article outlining the vision that led to Tidewave and how it moves from code understanding to system understanding.",
+      "url": "https://dashbit.co/blog/the-path-to-tidewave"
+    },
+    {
+      "type": "article",
+      "title": "Tidewave Web: in-browser coding agent for Phoenix (community discussion)",
+      "description": "Elixir Forum thread announcing and discussing Tidewave’s Phoenix integration, with community feedback.",
+      "url": "https://elixirforum.com/t/tidewave-web-in-browser-coding-agent-for-phoenix-and-liveview/72164"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Add community resources for these packages

```
$ tree priv/community_resources/
priv/community_resources/
├── bandit.json
├── bunt.json
├── cachex.json
├── ecto.json
├── hackney.json
├── hammer.json
├── jason.json
├── jose.json
├── nebulex.json
├── nimble_parsec.json
├── oban.json
├── phoenix.json
├── plug.json
├── poison.json
├── postgrex.json
├── ranch.json
├── req.json
├── tailwind.json
├── telemetry.json
├── tidewave.json
└── tower.json
```

## Testing Instructions

1. Run `mix clean`
2. Run `mix compile`
3. Run `mix phx.server`

**Test Case 1** Search any of the packages mentioned above and you should see a list of community resources for it.

## Screenshot

<img width="1427" height="823" alt="Screenshot 2025-10-24 at 3 33 44 PM" src="https://github.com/user-attachments/assets/cdc9638b-1cdd-410f-9108-a3cf04ad5a82" />