### PR TITLE
bug(jason-links): fix jason community resources links

### DIFF
--- a/priv/community_resources/jason.json
+++ b/priv/community_resources/jason.json
@@ -4,25 +4,25 @@
       "type": "article",
       "title": "Serialize and Deserialize JSON in Elixir",
       "description": "Step-by-step guide on encoding/decoding JSON with Jason, pitfalls, and custom encoders/decoders.",
-      "url": "[https://ssojet.com/serialize-and-deserialize/serialize-and-deserialize-json-in-elixir/](https://ssojet.com/serialize-and-deserialize/serialize-and-deserialize-json-in-elixir/)"
+      "url": "https://ssojet.com/serialize-and-deserialize/serialize-and-deserialize-json-in-elixir/"
     },
     {
       "type": "article",
       "title": "Custom JSON encoding for structs in Elixir with Jason",
       "description": "How to implement custom Jason.Encoder for your structs, with examples and rationale.",
-      "url": "[https://www.chriis.dev/opinion/how-to-custom-jason-encoding-for-structs-in-elixir](https://www.chriis.dev/opinion/how-to-custom-jason-encoding-for-structs-in-elixir)"
+      "url": "https://www.chriis.dev/opinion/how-to-custom-jason-encoding-for-structs-in-elixir"
     },
     {
       "type": "article",
       "title": "Jason: a blazing fast JSON parser and generator in pure Elixir",
       "description": "Community discussion and benchmarks around Jason vs other JSON libraries.",
-      "url": "[https://elixirforum.com/t/jason-a-blazing-fast-json-parser-and-generator-in-pure-elixir/11030](https://elixirforum.com/t/jason-a-blazing-fast-json-parser-and-generator-in-pure-elixir/11030)"
+      "url": "https://elixirforum.com/t/jason-a-blazing-fast-json-parser-and-generator-in-pure-elixir/11030"
     },
     {
       "type": "article",
       "title": "How to have custom encoding for struct using Jason?",
       "description": "StackOverflow thread showing patterns for custom encoding and common gotchas.",
-      "url": "[https://stackoverflow.com/questions/71436312/how-to-have-custom-enconding-for-struct-using-jason](https://stackoverflow.com/questions/71436312/how-to-have-custom-enconding-for-struct-using-jason)"
+      "url": "https://stackoverflow.com/questions/71436312/how-to-have-custom-enconding-for-struct-using-jason"
     }
   ]
 }


### PR DESCRIPTION
Fixes this error

```
** (ArgumentError) unsupported scheme given to <.link>. In case you want to link to an
unknown or unsafe scheme, such as javascript, use a tuple: {:javascript, rest}

    (phoenix_live_view 1.1.13) lib/phoenix_live_view/utils.ex:575: Phoenix.LiveView.Utils.valid_string_destination!/2
    (phoenix_live_view 1.1.13) lib/phoenix_component.ex:3108: Phoenix.Component."link (overridable 1)"/1
    (phoenix_live_view 1.1.13) lib/phoenix_live_view/tag_engine.ex:109: Phoenix.LiveView.TagEngine.component/3
    (toolbox 0.1.0) lib/toolbox_web/components/community_resources.ex:20: anonymous fn/6 in ToolboxWeb.Components.CommunityResources."community_resources (overridable 1)"/1
    (phoenix_live_view 1.1.13) lib/phoenix_live_view/diff.ex:729: Phoenix.LiveView.Diff.process_keyed/5
    (phoenix_live_view 1.1.13) lib/phoenix_live_view/diff.ex:665: anonymous fn/6 in Phoenix.LiveView.Diff.traverse_keyed/8
    (elixir 1.18.4) lib/enum.ex:2546: Enum."-reduce/3-lists^foldl/2-0-"/3
    (phoenix_live_view 1.1.13) lib/phoenix_live_view/diff.ex:646: Phoenix.LiveView.Diff.traverse_keyed/8

app           = toolbox
environment   = production
id            = 019a26f6-ba49-7db0-a604-38aef106a401
similarity_id = 51786934
metadata      = %{application: %{name: :toolbox, version: "0.1.0"}, tower: %{user_agent: "Mozilla/5.0 (compatible; DataForSeoBot/1.0; +https://dataforseo.com/dataforseo-bot)", package_name: "jason"}}
```