### PR TITLE
feat: add Schema.org JSON-LD and llms.txt for AEO

### DIFF
--- a/lib/toolbox_web.ex
+++ b/lib/toolbox_web.ex
@@ -17,7 +17,18 @@ defmodule ToolboxWeb do
   those modules here.
   """
 
-  def static_paths, do: ~w(assets fonts images files robots.txt sitemap.txt)
+  # Static assets served from priv/static
+  @static_paths ~w(
+    assets
+    fonts
+    images
+    files
+    robots.txt
+    sitemap.txt
+    llms.txt
+  )
+
+  def static_paths, do: @static_paths
 
   def router do
     quote do

--- a/lib/toolbox_web/components/layouts.ex
+++ b/lib/toolbox_web/components/layouts.ex
@@ -12,6 +12,34 @@ defmodule ToolboxWeb.Layouts do
 
   embed_templates "layouts/*"
 
+  def website_json_ld do
+    base_url = url(~p"/")
+
+    %{
+      "@context" => "https://schema.org",
+      "@type" => "WebSite",
+      "name" => "Elixir Observer",
+      "url" => base_url,
+      "description" =>
+        "Find, compare, and explore Elixir packages for your next project. " <>
+          "Search 2000+ packages with GitHub activity insights.",
+      "potentialAction" => %{
+        "@type" => "SearchAction",
+        "target" => %{
+          "@type" => "EntryPoint",
+          "urlTemplate" => "#{base_url}searches/{search_term_string}"
+        },
+        "query-input" => "required name=search_term_string"
+      },
+      "publisher" => %{
+        "@type" => "Organization",
+        "name" => "Mimiquate",
+        "url" => "https://mimiquate.com"
+      }
+    }
+    |> Jason.encode!()
+  end
+
   def og_title(%{package: %{name: name}}) do
     name
   end

--- a/lib/toolbox_web/components/layouts/root.html.heex
+++ b/lib/toolbox_web/components/layouts/root.html.heex
@@ -26,6 +26,10 @@
 
     <meta name="robots" content={robots(assigns)} />
 
+    <script type="application/ld+json">
+      {website_json_ld()}
+    </script>
+
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
 
     <%!-- Custom Fonts --%>

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -88,6 +88,31 @@ defmodule ToolboxWeb.PackageLive do
         false
       end
 
+    package_assigns = %{
+      id: package.id,
+      name: package.name,
+      category: package.category,
+      description: package.description,
+      owners_sync_at: package.hexpm_owners_sync_at,
+      owners: package.hexpm_owners,
+      recent_downloads: hexpm_data["downloads"]["recent"],
+      versions: versions,
+      latest_version_at: hd(hexpm_data["releases"])["inserted_at"],
+      latest_stable_version: hexpm_data["latest_stable_version"],
+      latest_stable_version_data: package.hexpm_latest_stable_version_data,
+      html_url: hexpm_data["html_url"],
+      changelog_url: changelog_url(hexpm_data, github.data),
+      docs_html_url: hexpm_data["docs_html_url"],
+      hexpm_created_at: hexpm_data["inserted_at"],
+      github_repo_url: github.data["html_url"],
+      github_fullname: github.data["full_name"],
+      stargazers_count: github.data["stargazers_count"],
+      activity: github.activity,
+      github_sync_at: github.sync_at,
+      is_following: is_following,
+      community_resources: community_resources
+    }
+
     {
       :ok,
       assign(
@@ -96,30 +121,8 @@ defmodule ToolboxWeb.PackageLive do
         search_term: "",
         related_packages: related_packages,
         related_packages_count: related_packages_count,
-        package: %{
-          id: package.id,
-          name: package.name,
-          category: package.category,
-          description: package.description,
-          owners_sync_at: package.hexpm_owners_sync_at,
-          owners: package.hexpm_owners,
-          recent_downloads: hexpm_data["downloads"]["recent"],
-          versions: versions,
-          latest_version_at: hd(hexpm_data["releases"])["inserted_at"],
-          latest_stable_version: hexpm_data["latest_stable_version"],
-          latest_stable_version_data: package.hexpm_latest_stable_version_data,
-          html_url: hexpm_data["html_url"],
-          changelog_url: changelog_url(hexpm_data, github.data),
-          docs_html_url: hexpm_data["docs_html_url"],
-          hexpm_created_at: hexpm_data["inserted_at"],
-          github_repo_url: github.data["html_url"],
-          github_fullname: github.data["full_name"],
-          stargazers_count: github.data["stargazers_count"],
-          activity: github.activity,
-          github_sync_at: github.sync_at,
-          is_following: is_following,
-          community_resources: community_resources
-        }
+        json_ld_schema: package_json_ld(package_assigns, url(~p"/packages/#{package.name}")),
+        package: package_assigns
       )
     }
   end
@@ -307,5 +310,55 @@ defmodule ToolboxWeb.PackageLive do
 
   defp source_url(name, version) do
     "https://preview.hex.pm/preview/#{name}/#{version}"
+  end
+
+  defp package_json_ld(package, package_url) do
+    %{
+      "@context" => "https://schema.org",
+      "@type" => "SoftwareApplication",
+      "name" => package.name,
+      "description" => package.description,
+      "applicationCategory" => "Developer Tools",
+      "operatingSystem" => "Elixir/Erlang BEAM VM",
+      "url" => package_url,
+      "downloadUrl" => package.html_url,
+      "softwareVersion" => package.latest_stable_version,
+      "datePublished" => package.hexpm_created_at,
+      "dateModified" => package.latest_version_at,
+      "offers" => %{
+        "@type" => "Offer",
+        "price" => "0",
+        "priceCurrency" => "USD"
+      },
+      "isAccessibleForFree" => true,
+      "license" => "https://opensource.org/licenses"
+    }
+    |> maybe_add_aggregate_rating(package)
+    |> maybe_add_same_as(package)
+    |> Jason.encode!()
+  end
+
+  defp maybe_add_aggregate_rating(schema, %{stargazers_count: nil}), do: schema
+  defp maybe_add_aggregate_rating(schema, %{stargazers_count: 0}), do: schema
+
+  defp maybe_add_aggregate_rating(schema, %{stargazers_count: count}) do
+    Map.put(schema, "aggregateRating", %{
+      "@type" => "AggregateRating",
+      "ratingValue" => 5,
+      "ratingCount" => count,
+      "bestRating" => 5,
+      "worstRating" => 1
+    })
+  end
+
+  defp maybe_add_same_as(schema, package) do
+    same_as =
+      [package.html_url, package.github_repo_url, package.docs_html_url]
+      |> Enum.reject(&is_nil/1)
+
+    case same_as do
+      [] -> schema
+      urls -> Map.put(schema, "sameAs", urls)
+    end
   end
 end

--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -1,3 +1,7 @@
+<script type="application/ld+json">
+  {@json_ld_schema}
+</script>
+
 <article class="pt-3 sm:pt-10">
   <section class="flex flex-wrap sm:flex-nowrap min-w-40 justify-between pb-3 sm:pb-10">
     <div class="w-full">

--- a/priv/static/llms.txt
+++ b/priv/static/llms.txt
@@ -1,0 +1,58 @@
+# Elixir Observer
+
+> Elixir Observer is a comprehensive search engine and explorer for the Elixir ecosystem. Find, compare, and discover Elixir packages from Hex.pm with real-time GitHub activity insights, maintenance status, and community resources.
+
+## What Makes Elixir Observer Different
+
+Unlike Hex.pm (the official package registry), Elixir Observer provides:
+
+- **GitHub Activity Data**: Stars, recent commits, unreleased changes
+- **Maintenance Status**: See if a package is actively maintained based on commit history
+- **Package Comparisons**: Related packages in the same category
+- **Community Resources**: Tutorials, articles, and talks about each package
+- **Download Trends**: 90-day download statistics
+
+## Main Pages
+
+- [Home](https://elixir-observer.com/): Search and discover Elixir packages
+- [Categories](https://elixir-observer.com/categories): Browse packages organized by category
+- [About](https://elixir-observer.com/about): Learn about Elixir Observer
+
+## Popular Package Categories
+
+- [Web Frameworks](https://elixir-observer.com/categories/web-frameworks): Phoenix, Plug, Bandit
+- [Database](https://elixir-observer.com/categories/database): Ecto, Postgrex, Ecto SQL
+- [Authentication](https://elixir-observer.com/categories/authentication): Guardian, Pow, Ueberauth
+- [Testing](https://elixir-observer.com/categories/testing): ExUnit, Mox, ExMachina
+- [HTTP Clients](https://elixir-observer.com/categories/http-clients): Req, Finch, HTTPoison
+
+## Most Popular Packages
+
+- [Phoenix](https://elixir-observer.com/packages/phoenix): Peace of mind from prototype to production
+- [Ecto](https://elixir-observer.com/packages/ecto): A toolkit for data mapping and language integrated query
+- [Plug](https://elixir-observer.com/packages/plug): Compose web applications with functions
+- [Jason](https://elixir-observer.com/packages/jason): A blazing fast JSON parser and generator
+- [Swoosh](https://elixir-observer.com/packages/swoosh): Compose, deliver and test your emails easily
+- [Oban](https://elixir-observer.com/packages/oban): Robust job processing in Elixir
+- [LiveView](https://elixir-observer.com/packages/phoenix_live_view): Rich, real-time user experiences with server-rendered HTML
+
+## Common Questions This Site Can Answer
+
+- Is [package name] actively maintained?
+- What are the most popular Elixir packages for [category]?
+- How many GitHub stars does [package] have?
+- When was the last release of [package]?
+- What are alternatives to [package]?
+- What packages depend on [package]?
+
+## Technical Details
+
+- Data synced from Hex.pm and GitHub APIs
+- ~2000+ Elixir packages indexed
+- Updated hourly for activity data
+- Built with Phoenix LiveView
+
+## Contact
+
+- GitHub: https://github.com/mimiquate/elixir_observer
+- Website: https://elixir-observer.com

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -4,3 +4,7 @@ User-agent: *
 Disallow:
 
 Sitemap: https://elixir-observer.com/sitemap.txt
+
+# LLM context file
+# See https://llmstxt.org for more information
+LLMsTxt: https://elixir-observer.com/llms.txt

--- a/test/toolbox_web/live/package_live_test.exs
+++ b/test/toolbox_web/live/package_live_test.exs
@@ -405,4 +405,119 @@ defmodule ToolboxWeb.PackageLiveTest do
       assert Toolbox.Users.following_package?(user.id, package.id) == true
     end
   end
+
+  describe "JSON-LD Schema" do
+    setup do
+      {:ok, package} = create(:package, name: "phoenix", description: "Web framework for Elixir")
+      {:ok, _} = create(:hexpm_snapshot, package_id: package.id)
+
+      [package: package]
+    end
+
+    test "renders JSON-LD script tag", %{conn: conn, package: package} do
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      assert html =~ ~s(<script type="application/ld+json">)
+      assert html =~ ~s("@context":"https://schema.org")
+      assert html =~ ~s("@type":"SoftwareApplication")
+    end
+
+    test "includes package name and description in JSON-LD", %{conn: conn, package: package} do
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "SoftwareApplication")
+
+      assert json_ld["name"] == package.name
+      assert json_ld["description"] == package.description
+    end
+
+    test "includes package URLs in JSON-LD", %{conn: conn, package: package} do
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "SoftwareApplication")
+
+      assert json_ld["url"] =~ "/packages/#{package.name}"
+      assert json_ld["applicationCategory"] == "Developer Tools"
+      assert json_ld["operatingSystem"] == "Elixir/Erlang BEAM VM"
+    end
+
+    test "includes aggregateRating when package has GitHub stars", %{conn: conn, package: package} do
+      {:ok, _} =
+        Packages.upsert_github_snapshot(%{
+          package_id: package.id,
+          data: %{
+            "stargazers_count" => 21000,
+            "full_name" => "phoenixframework/phoenix",
+            "html_url" => "https://github.com/phoenixframework/phoenix"
+          }
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "SoftwareApplication")
+
+      assert json_ld["aggregateRating"]["@type"] == "AggregateRating"
+      assert json_ld["aggregateRating"]["ratingCount"] == 21000
+      assert json_ld["aggregateRating"]["ratingValue"] == 5
+    end
+
+    test "does not include aggregateRating when package has no GitHub stars", %{
+      conn: conn,
+      package: package
+    } do
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "SoftwareApplication")
+
+      refute Map.has_key?(json_ld, "aggregateRating")
+    end
+
+    test "includes sameAs with external URLs when available", %{conn: conn, package: package} do
+      {:ok, _} =
+        Packages.upsert_github_snapshot(%{
+          package_id: package.id,
+          data: %{
+            "stargazers_count" => 100,
+            "full_name" => "phoenixframework/phoenix",
+            "html_url" => "https://github.com/phoenixframework/phoenix"
+          }
+        })
+
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "SoftwareApplication")
+
+      assert is_list(json_ld["sameAs"])
+      assert "https://github.com/phoenixframework/phoenix" in json_ld["sameAs"]
+    end
+
+    test "includes offer with free price", %{conn: conn, package: package} do
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "SoftwareApplication")
+
+      assert json_ld["offers"]["@type"] == "Offer"
+      assert json_ld["offers"]["price"] == "0"
+      assert json_ld["offers"]["priceCurrency"] == "USD"
+      assert json_ld["isAccessibleForFree"] == true
+    end
+
+    test "renders WebSite JSON-LD in root layout", %{conn: conn, package: package} do
+      {:ok, _view, html} = live(conn, ~p"/packages/#{package.name}")
+
+      json_ld = extract_json_ld(html, "WebSite")
+
+      assert json_ld["name"] == "Elixir Observer"
+      assert json_ld["url"] =~ "/"
+      assert json_ld["potentialAction"]["@type"] == "SearchAction"
+    end
+
+    defp extract_json_ld(html, type) do
+      ~r/<script type="application\/ld\+json">\s*(.+?)\s*<\/script>/s
+      |> Regex.scan(html, capture: :all_but_first)
+      |> Enum.map(&List.first/1)
+      |> Enum.map(&Jason.decode!/1)
+      |> Enum.find(&(&1["@type"] == type))
+    end
+  end
 end


### PR DESCRIPTION
  Elixir Observer already has valuable data that other platforms doesn't  shows. GH activity, maintenance status, stars, community resources, but it's all in plain HTML. LLMs and answer engines can't easily parse or cite it.                                 

This PR adds structured data (JSON-LD) so that information becomes machine-readable and more likely to surface in  AI-powered search results.                                     
                                                                 
  ## Changes                                                     
                                                                 
  - **Package pages**: JSON-LD with package info, version, GitHub
   stars, and external links                                     
  - **Root layout**: WebSite schema with SearchAction            
  - **llms.txt**: Description of the site, popular packages, and 
  categories                                                     
  - **robots.txt**: Added reference to llms.txt                  
  - **Tests**: Coverage for JSON-LD generation                   
                                                                   
  ## References                                                  
                                                                 
  - [Schema.org SoftwareApplication](https://schema.org/SoftwareApplication)   
  - [llmstxt.org specification](https://llmstxt.org/)            
  - [Google Structured Data Guide](https://developers.google.com/search/docs/appearance/structured-data) 