### PR TITLE
fix: increase category worker receive timeout

### DIFF
--- a/lib/toolbox/tasks/category.ex
+++ b/lib/toolbox/tasks/category.ex
@@ -92,7 +92,7 @@ defmodule Toolbox.Tasks.Category do
           {"user-agent", "elixir client"}
         ],
         json: body,
-        receive_timeout: 120_000
+        receive_timeout: 600_000
       )
 
     case categorization_response do


### PR DESCRIPTION
Exception:

```
** (CaseClauseError) no case clause matching: {:error, %Req.TransportError{reason: :timeout}}
    (toolbox 0.1.0) lib/toolbox/tasks/category.ex:98: Toolbox.Tasks.Category.run/1
    (toolbox 0.1.0) lib/toolbox/workers/category_worker.ex:21: Toolbox.Workers.CategoryWorker.perform/1
    (oban 2.20.1) lib/oban/queue/executor.ex:150: Oban.Queue.Executor.perform/1
    (oban 2.20.1) lib/oban/queue/executor.ex:77: Oban.Queue.Executor.call/1
    (elixir 1.18.4) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.18.4) lib/task/supervised.ex:36: Task.Supervised.reply/4

app           = toolbox
environment   = production
id            = 019e2048-786f-72cc-9734-4f27a8f3c6d5
similarity_id = 95141400
metadata      = %{
  process: %{pid: #PID<0.14322617.0>, process_label: Toolbox.Workers.CategoryWorker},
  oban: %{
    conf: %{name: Oban, engine: Oban.Engines.Basic},
    job: %{id: 1570408, max_attempts: 10, worker: "Toolbox.Workers.CategoryWorker", attempt: 10}
  }
}
```