### PR TITLE
fix: fall back to first version when hexpm latest_stable_version is nil

### DIFF
--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -126,8 +126,8 @@ defmodule ToolboxWeb.PackageLive do
 
   def handle_params(params, _uri, socket) do
     package = socket.assigns.package
-    version = params["version"] || package.latest_stable_version
     versions = Enum.map(package.versions, & &1.version)
+    version = params["version"] || package.latest_stable_version || List.first(versions)
 
     if version not in versions do
       raise HexpmVersionNotFoundError, "#{version} not found for #{package.name}"

--- a/test/toolbox_web/live/package_live_test.exs
+++ b/test/toolbox_web/live/package_live_test.exs
@@ -66,6 +66,36 @@ defmodule ToolboxWeb.PackageLiveTest do
              }
     end
 
+    test "falls back to the first version when latest_stable_version is nil", %{
+      conn: conn,
+      package: package
+    } do
+      {:ok, _} =
+        Packages.create_hexpm_snapshot(%{
+          package_id: package.id,
+          data: %{
+            "meta" => %{"description" => "A pure Elixir HTTP server"},
+            "downloads" => %{"recent" => 1000},
+            "docs_html_url" => "https://hexdocs.pm/bandit/",
+            "releases" => [
+              %{
+                "version" => "2.0.0-rc.1",
+                "url" => "https://hex.pm/api/packages/bandit/releases/2.0.0-rc.1",
+                "has_docs" => true,
+                "inserted_at" => "2025-05-29T16:57:22.358745Z"
+              }
+            ],
+            "inserted_at" => "2020-11-05T17:11:46.440731Z",
+            "latest_version" => "2.0.0-rc.1",
+            "latest_stable_version" => nil
+          }
+        })
+
+      {:ok, view, _html} = live(conn, ~p"/packages/#{package.name}")
+
+      assert has_element?(view, "h2", "Version 2.0.0-rc.1")
+    end
+
     test "handles invalid version gracefully", %{conn: conn, package: package} do
       assert_raise ToolboxWeb.PackageLive.HexpmVersionNotFoundError, fn ->
         live(conn, ~p"/packages/#{package.name}/invalid_version")


### PR DESCRIPTION
Packages without a stable release (only pre-releases) return a nil latest_stable_version from hexpm, which previously raised HexpmVersionNotFoundError on the package page.

```
{
  "meta": {
    "links": {
      "GitHub": "https://github.com/IanLuites/adapter"
    },
    "description": "Fast adapters with clear syntax and build-in safety.",
    "licenses": [
      "MIT"
    ],
    "maintainers": []
  },
  "name": "adapter",
  "url": "https://hex.pm/api/packages/adapter",
  "owners": [
    {
      "url": "https://hex.pm/api/users/ianluites",
      "username": "ianluites",
      "email": "ianluites@gmail.com"
    }
  ],
  "inserted_at": "2020-11-02T01:41:06.681469Z",
  "updated_at": "2020-11-02T01:41:09.176994Z",
  "repository": "hexpm",
  "releases": [
    {
      "version": "1.0.0-rc0",
      "url": "https://hex.pm/api/packages/adapter/releases/1.0.0-rc0",
      "has_docs": true,
      "inserted_at": "2020-11-02T01:41:06.686797Z"
    }
  ],
  "html_url": "https://hex.pm/packages/adapter",
  "downloads": {
    "all": 19442,
    "recent": 9387,
    "week": 5
  },
  "security_advisories": [],
  "latest_version": "1.0.0-rc0",
  "docs_html_url": "https://adapter.hexdocs.pm/",
  "retirements": {

  },
  "configs": {
    "erlang.mk": "dep_adapter = hex 1.0.0-rc0",
    "mix.exs": "{:adapter, \"~\u003E 1.0.0-rc0\"}",
    "rebar.config": "{adapter, \"1.0.0-rc0\"}"
  },
  "latest_stable_version": null
}
```