### PR TITLE
Fix hexpm worker latest stable version

### DIFF
--- a/lib/toolbox/hexpm.ex
+++ b/lib/toolbox/hexpm.ex
@@ -1,6 +1,4 @@
 defmodule Toolbox.Hexpm do
-  @base_url "https://hex.pm/api"
-
   use Nebulex.Caching, cache: Toolbox.Cache
 
   def get_page(page) do
@@ -12,7 +10,7 @@ defmodule Toolbox.Hexpm do
   end
 
   def get(path) do
-    Req.get("#{@base_url}/#{path}", headers: [{"user-agent", "toolbox"}])
+    Req.get("#{base_url()}/#{path}", headers: [{"user-agent", "toolbox"}])
   end
 
   @decorate cacheable(key: {:hexpm_version, name, version}, opts: [ttl: :timer.hours(24)])
@@ -22,6 +20,12 @@ defmodule Toolbox.Hexpm do
 
   @decorate cacheable(key: {:hexpm_owner, package_name}, opts: [ttl: :timer.hours(24)])
   def get_package_owners(package_name) do
-    Req.get("#{@base_url}/packages/#{package_name}/owners", headers: [{"user-agent", "toolbox"}])
+    Req.get("#{base_url()}/packages/#{package_name}/owners", headers: [{"user-agent", "toolbox"}])
+  end
+
+  if Mix.env() == :test do
+    defp base_url, do: ProcessTree.get({__MODULE__, :base_url})
+  else
+    defp base_url, do: "https://hex.pm/api"
   end
 end

--- a/lib/toolbox/workers/hexpm_worker.ex
+++ b/lib/toolbox/workers/hexpm_worker.ex
@@ -48,13 +48,11 @@ defmodule Toolbox.Workers.HexpmWorker do
   def perform(%Oban.Job{
         args: %{"action" => "get_latest_stable_version", "name" => name, "version" => version}
       }) do
-    with %Toolbox.Package{} = package <- Toolbox.Packages.get_package_by_name(name),
-         {:ok, %{status: 200, body: version_data}} <-
-           Toolbox.Hexpm.get_package_version(name, version),
+    with {:ok, package} <- get_package_by_name(name),
+         {:ok, version_data} <- get_package_version(name, version),
          {:ok, p} <-
            Toolbox.Packages.update_package_latest_stable_version(package, %{
-             hexpm_latest_stable_version_data:
-               Toolbox.Package.HexpmVersion.build_version_from_api_response(version_data)
+             hexpm_latest_stable_version_data: version_data
            }) do
       Phoenix.PubSub.broadcast(
         Toolbox.PubSub,
@@ -67,21 +65,36 @@ defmodule Toolbox.Workers.HexpmWorker do
 
       {:ok, p}
     else
-      nil ->
-        Logger.warning("HEXPM package #{name} not found in database")
+      {:skip, reason} ->
+        Logger.warning(reason)
 
         :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp get_package_by_name(name) do
+    case Toolbox.Packages.get_package_by_name(name) do
+      %Toolbox.Package{} = package -> {:ok, package}
+      nil -> {:skip, "package #{name} not found"}
+    end
+  end
+
+  defp get_package_version(name, version) do
+    case Toolbox.Hexpm.get_package_version(name, version) do
+      {:ok, %{status: 200, body: version_data}} ->
+        {:ok, Toolbox.Package.HexpmVersion.build_version_from_api_response(version_data)}
 
       {:ok, %{status: status}} when status in [400, 404, 429] ->
-        Logger.warning("Unable to fetch hexpm version for #{name} version #{version}")
-
-        :ok
+        {:skip, "Unable to fetch hexpm version for #{name} version #{version}"}
 
       {:ok, %{status: status}} ->
         {:error, "failed to fetch hexpm version #{version} for #{name} with status #{status}"}
 
-      {:error, _reason} = error ->
-        error
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 end

--- a/lib/toolbox/workers/hexpm_worker.ex
+++ b/lib/toolbox/workers/hexpm_worker.ex
@@ -1,6 +1,8 @@
 defmodule Toolbox.Workers.HexpmWorker do
   use Oban.Worker, queue: :hexpm, max_attempts: 3
 
+  require Logger
+
   @impl Oban.Worker
   def perform(%Oban.Job{meta: %{"cron" => true}}) do
     Toolbox.Tasks.Hexpm.run()
@@ -36,30 +38,50 @@ defmodule Toolbox.Workers.HexpmWorker do
   end
 
   def perform(%Oban.Job{
+        args: %{"action" => "get_latest_stable_version", "name" => name, "version" => nil}
+      }) do
+    Logger.warning("HEXPM package #{name} has no latest stable version, skipping version fetch")
+
+    :ok
+  end
+
+  def perform(%Oban.Job{
         args: %{"action" => "get_latest_stable_version", "name" => name, "version" => version}
       }) do
-    {:ok, %{status: 200, body: version_data}} = Toolbox.Hexpm.get_package_version(name, version)
+    with %Toolbox.Package{} = package <- Toolbox.Packages.get_package_by_name(name),
+         {:ok, %{status: 200, body: version_data}} <-
+           Toolbox.Hexpm.get_package_version(name, version),
+         {:ok, p} <-
+           Toolbox.Packages.update_package_latest_stable_version(package, %{
+             hexpm_latest_stable_version_data:
+               Toolbox.Package.HexpmVersion.build_version_from_api_response(version_data)
+           }) do
+      Phoenix.PubSub.broadcast(
+        Toolbox.PubSub,
+        "package_live:#{name}",
+        %{
+          action: :refresh_latest_stable_version,
+          latest_stable_version_data: p.hexpm_latest_stable_version_data
+        }
+      )
 
-    Toolbox.Packages.get_package_by_name(name)
-    |> Toolbox.Packages.update_package_latest_stable_version(%{
-      hexpm_latest_stable_version_data:
-        Toolbox.Package.HexpmVersion.build_version_from_api_response(version_data)
-    })
-    |> case do
-      {:ok, p} ->
-        Phoenix.PubSub.broadcast(
-          Toolbox.PubSub,
-          "package_live:#{name}",
-          %{
-            action: :refresh_latest_stable_version,
-            latest_stable_version_data: p.hexpm_latest_stable_version_data
-          }
-        )
+      {:ok, p}
+    else
+      nil ->
+        Logger.warning("HEXPM package #{name} not found in database")
 
-        {:ok, p}
+        :ok
 
-      err ->
-        err
+      {:ok, %{status: status}} when status in [400, 404, 429] ->
+        Logger.warning("Unable to fetch hexpm version for #{name} version #{version}")
+
+        :ok
+
+      {:ok, %{status: status}} ->
+        {:error, "failed to fetch hexpm version #{version} for #{name} with status #{status}"}
+
+      {:error, _reason} = error ->
+        error
     end
   end
 end

--- a/lib/toolbox/workers/hexpm_worker.ex
+++ b/lib/toolbox/workers/hexpm_worker.ex
@@ -40,7 +40,7 @@ defmodule Toolbox.Workers.HexpmWorker do
   def perform(%Oban.Job{
         args: %{"action" => "get_latest_stable_version", "name" => name, "version" => nil}
       }) do
-    Logger.warning("HEXPM package #{name} has no latest stable version, skipping version fetch")
+    Logger.warning("Hexpm package #{name} has no latest stable version, skipping version fetch")
 
     :ok
   end
@@ -87,11 +87,12 @@ defmodule Toolbox.Workers.HexpmWorker do
       {:ok, %{status: 200, body: version_data}} ->
         {:ok, Toolbox.Package.HexpmVersion.build_version_from_api_response(version_data)}
 
-      {:ok, %{status: status}} when status in [400, 404, 429] ->
+      {:ok, %{status: status}} when status in [400, 404] ->
         {:skip, "Unable to fetch hexpm version for #{name} version #{version}"}
 
-      {:ok, %{status: status}} ->
-        {:error, "failed to fetch hexpm version #{version} for #{name} with status #{status}"}
+      {:ok, %{status: server_error}} when server_error in 500..599 ->
+        {:error,
+         "failed to fetch hexpm version #{version} for #{name} with status #{server_error}"}
 
       {:error, reason} ->
         {:error, reason}

--- a/lib/toolbox_web.ex
+++ b/lib/toolbox_web.ex
@@ -101,6 +101,9 @@ defmodule ToolboxWeb do
 
       def humanized_number(_other), do: "-"
 
+      def humanized_stable_version(version) when is_binary(version), do: version
+      def humanized_stable_version(_other), do: "-"
+
       def humanized_datetime(datetime) when is_binary(datetime) do
         Calendar.strftime(
           NaiveDateTime.from_iso8601!(datetime),

--- a/lib/toolbox_web/live/package_live.ex
+++ b/lib/toolbox_web/live/package_live.ex
@@ -220,8 +220,9 @@ defmodule ToolboxWeb.PackageLive do
     latest_stable_version = package.latest_hexpm_snapshot.data["latest_stable_version"]
     latest_stable_version_data = package.hexpm_latest_stable_version_data
 
-    if !latest_stable_version_data or
-         latest_stable_version_data.version != latest_stable_version do
+    if is_binary(latest_stable_version) and
+         (!latest_stable_version_data or
+            latest_stable_version_data.version != latest_stable_version) do
       %{action: :get_latest_stable_version, name: package.name, version: latest_stable_version}
       |> Toolbox.Workers.HexpmWorker.new()
       |> Oban.insert()

--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -160,7 +160,7 @@
         </:icon>
         <div class="flex items-center">
           <h3 class="text-[20px] sm:text-[32px] font-semibold text-primary-text">
-            {@package.latest_stable_version || "-"}
+            {humanized_stable_version(@package.latest_stable_version)}
           </h3>
         </div>
       </.stats_card>

--- a/lib/toolbox_web/live/package_live.html.heex
+++ b/lib/toolbox_web/live/package_live.html.heex
@@ -160,7 +160,7 @@
         </:icon>
         <div class="flex items-center">
           <h3 class="text-[20px] sm:text-[32px] font-semibold text-primary-text">
-            {@package.latest_stable_version}
+            {@package.latest_stable_version || "-"}
           </h3>
         </div>
       </.stats_card>

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,6 +14,14 @@ defmodule Helpers do
 
     test_server
   end
+
+  def test_server_hexpm do
+    {:ok, test_server} = TestServer.start()
+
+    Process.put({Toolbox.Hexpm, :base_url}, TestServer.url(test_server))
+
+    test_server
+  end
 end
 
 Req.default_options(retry: false)

--- a/test/toolbox/workers/hexpm_worker_test.exs
+++ b/test/toolbox/workers/hexpm_worker_test.exs
@@ -68,7 +68,6 @@ defmodule Toolbox.Workers.HexpmWorkerTest do
     end
 
     test "returns :ok and never calls hex.pm when version is nil" do
-      Helpers.test_server_hexpm()
       {:ok, package} = create(:package)
 
       log =

--- a/test/toolbox/workers/hexpm_worker_test.exs
+++ b/test/toolbox/workers/hexpm_worker_test.exs
@@ -1,0 +1,108 @@
+defmodule Toolbox.Workers.HexpmWorkerTest do
+  use Toolbox.DataCase, async: true
+  use Oban.Testing, repo: Toolbox.Repo
+
+  import ExUnit.CaptureLog
+
+  alias Toolbox.Packages
+  alias Toolbox.Workers.HexpmWorker
+
+  describe "perform/1 with get_latest_stable_version" do
+    test "updates the package and broadcasts on success" do
+      test_server = Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      Phoenix.PubSub.subscribe(Toolbox.PubSub, "package_live:#{package.name}")
+
+      TestServer.add(test_server, "/packages/#{package.name}/releases/1.7.0",
+        to: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.send_resp(200, ~s({
+            "version": "1.7.0",
+            "meta": {"elixir": "~> 1.14"},
+            "has_docs": true,
+            "retirement": null,
+            "requirements": {},
+            "inserted_at": "2026-08-25T09:12:05Z",
+            "publisher": {"username": "someuser", "email": "user@example.com"}
+          }))
+        end
+      )
+
+      assert {:ok, %Toolbox.Package{} = updated} =
+               perform_job(HexpmWorker, %{
+                 action: "get_latest_stable_version",
+                 name: package.name,
+                 version: "1.7.0"
+               })
+
+      assert updated.hexpm_latest_stable_version_data.version == "1.7.0"
+
+      assert_receive %{
+        action: :refresh_latest_stable_version,
+        latest_stable_version_data: %{version: "1.7.0"}
+      }
+    end
+
+    @tag capture_log: true
+    test "returns :ok and skips the update on 404 (nonexistent release)" do
+      test_server = Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      TestServer.add(test_server, "/packages/#{package.name}/releases/1.0.0",
+        to: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.send_resp(404, ~s({"message": "Page not found", "status": 404}))
+        end
+      )
+
+      assert perform_job(HexpmWorker, %{
+               action: "get_latest_stable_version",
+               name: package.name,
+               version: "1.0.0"
+             }) == :ok
+
+      assert Packages.get_package_by_name(package.name).hexpm_latest_stable_version_data == nil
+    end
+
+    test "returns :ok and never calls hex.pm when version is nil" do
+      Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      log =
+        capture_log(fn ->
+          assert perform_job(HexpmWorker, %{
+                   action: "get_latest_stable_version",
+                   name: package.name,
+                   version: nil
+                 }) == :ok
+        end)
+
+      assert log =~ "has no latest stable version, skipping version fetch"
+      assert Packages.get_package_by_name(package.name).hexpm_latest_stable_version_data == nil
+    end
+
+    @tag capture_log: true
+    test "returns an error tuple on server errors so Oban retries" do
+      test_server = Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      TestServer.add(test_server, "/packages/#{package.name}/releases/1.7.0",
+        to: fn conn ->
+          Plug.Conn.send_resp(conn, 502, "")
+        end
+      )
+
+      assert {:error, message} =
+               perform_job(HexpmWorker, %{
+                 action: "get_latest_stable_version",
+                 name: package.name,
+                 version: "1.7.0"
+               })
+
+      assert message =~ "502"
+    end
+  end
+end

--- a/test/toolbox_web/live/package_live_test.exs
+++ b/test/toolbox_web/live/package_live_test.exs
@@ -96,6 +96,37 @@ defmodule ToolboxWeb.PackageLiveTest do
       assert has_element?(view, "h2", "Version 2.0.0-rc.1")
     end
 
+    test "does not enqueue a get_latest_stable_version job when latest_stable_version is nil",
+         %{conn: conn, package: package} do
+      {:ok, _} =
+        Packages.create_hexpm_snapshot(%{
+          package_id: package.id,
+          data: %{
+            "meta" => %{"description" => "A pure Elixir HTTP server"},
+            "downloads" => %{"recent" => 1000},
+            "docs_html_url" => "https://hexdocs.pm/bandit/",
+            "releases" => [
+              %{
+                "version" => "2.0.0-rc.1",
+                "url" => "https://hex.pm/api/packages/bandit/releases/2.0.0-rc.1",
+                "has_docs" => true,
+                "inserted_at" => "2025-05-29T16:57:22.358745Z"
+              }
+            ],
+            "inserted_at" => "2020-11-05T17:11:46.440731Z",
+            "latest_version" => "2.0.0-rc.1",
+            "latest_stable_version" => nil
+          }
+        })
+
+      {:ok, _view, _html} = live(conn, ~p"/packages/#{package.name}")
+
+      refute_enqueued(
+        worker: Toolbox.Workers.HexpmWorker,
+        args: %{action: "get_latest_stable_version"}
+      )
+    end
+
     test "handles invalid version gracefully", %{conn: conn, package: package} do
       assert_raise ToolboxWeb.PackageLive.HexpmVersionNotFoundError, fn ->
         live(conn, ~p"/packages/#{package.name}/invalid_version")


### PR DESCRIPTION
### Describe what this PR includes

Addresses issue #271 

This PR fixes `Toolbox.Workers.HexpmWorker` crashing with a `MatchError` when Hex.pm returns a non-200 status while fetching a package's latest stable version.

This happens for two reasons: a package with no stable release at all that builds a malformed request URL and a package whose cached `latest_stable_version` points to a release that no longer exists, both requests used to return an unhandled 404.

### Changes

- Guard against enqueuing a `get_latest_stable_version` job when `latest_stable_version` is `nil`.
- Add a defensive `perform/1` clause in `HexpmWorker` for jobs already enqueued with `version: nil` before the fix.
- Handle non-200 responses from `Toolbox.Hexpm.get_package_version/2` instead of crashing, log and complete for 400/404/429, return an error so Oban retries for 5xx.
- Check the package still exists locally before calling Hex.pm, so a deleted package doesn't trigger a wasted request.
- Add a `base_url/0` to `Toolbox.Hexpm`, mirroring the existing pattern in `Toolbox.Github`.
- Show - instead of a blank value on the package page when `latest_stable_version` is `nil`.

### Testing

- Add tests for `HexpmWorker.perform/1` covering a successful fetch, a well-formed but reverted version, version: `nil`, and a 5xx response.
- Extend the `PackageLive` test to confirm no `get_latest_stable_version` job is enqueued when `latest_stable_version` is `nil`.

### Screenshots

<img width="1470" height="491" alt="image" src="https://github.com/user-attachments/assets/890ef1f2-348f-456b-9c60-cda82cc37ed0" />
