### PR TITLE
Fix hexpm worker package owners

### DIFF
--- a/lib/toolbox/workers/hexpm_worker.ex
+++ b/lib/toolbox/workers/hexpm_worker.ex
@@ -11,10 +11,10 @@ defmodule Toolbox.Workers.HexpmWorker do
   end
 
   def perform(%Oban.Job{args: %{"action" => "get_package_owners", "name" => name}}) do
-    with {:ok, owners_data} <- get_package_owners(name),
+    with {:ok, package} <- get_package_by_name(name),
+         {:ok, owners_data} <- get_package_owners(name),
          {:ok, p} <-
-           Toolbox.Packages.get_package_by_name(name)
-           |> Toolbox.Packages.update_package_owners(%{
+           Toolbox.Packages.update_package_owners(package, %{
              hexpm_owners_sync_at: DateTime.utc_now(),
              hexpm_owners: owners_data
            }) do

--- a/lib/toolbox/workers/hexpm_worker.ex
+++ b/lib/toolbox/workers/hexpm_worker.ex
@@ -11,29 +11,31 @@ defmodule Toolbox.Workers.HexpmWorker do
   end
 
   def perform(%Oban.Job{args: %{"action" => "get_package_owners", "name" => name}}) do
-    {:ok, %{status: 200, body: owners_data}} = Toolbox.Hexpm.get_package_owners(name)
+    with {:ok, owners_data} <- get_package_owners(name),
+         {:ok, p} <-
+           Toolbox.Packages.get_package_by_name(name)
+           |> Toolbox.Packages.update_package_owners(%{
+             hexpm_owners_sync_at: DateTime.utc_now(),
+             hexpm_owners: owners_data
+           }) do
+      Phoenix.PubSub.broadcast(
+        Toolbox.PubSub,
+        "package_live:#{name}",
+        %{
+          action: :refresh_owners,
+          owners_sync_at: p.hexpm_owners_sync_at,
+          owners: p.hexpm_owners
+        }
+      )
 
-    Toolbox.Packages.get_package_by_name(name)
-    |> Toolbox.Packages.update_package_owners(%{
-      hexpm_owners_sync_at: DateTime.utc_now(),
-      hexpm_owners: owners_data
-    })
-    |> case do
-      {:ok, p} ->
-        Phoenix.PubSub.broadcast(
-          Toolbox.PubSub,
-          "package_live:#{name}",
-          %{
-            action: :refresh_owners,
-            owners_sync_at: p.hexpm_owners_sync_at,
-            owners: p.hexpm_owners
-          }
-        )
+      {:ok, p}
+    else
+      {:skip, reason} ->
+        Logger.warning(reason)
+        :ok
 
-        {:ok, p}
-
-      err ->
-        err
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -93,6 +95,22 @@ defmodule Toolbox.Workers.HexpmWorker do
       {:ok, %{status: server_error}} when server_error in 500..599 ->
         {:error,
          "failed to fetch hexpm version #{version} for #{name} with status #{server_error}"}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp get_package_owners(name) do
+    case Toolbox.Hexpm.get_package_owners(name) do
+      {:ok, %{status: 200, body: owners_data}} ->
+        {:ok, owners_data}
+
+      {:ok, %{status: status}} when status in [400, 404] ->
+        {:skip, "Unable to fetch hexpm owners for #{name}"}
+
+      {:ok, %{status: server_error}} when server_error in 500..599 ->
+        {:error, "failed to fetch hexpm owners for #{name} with status #{server_error}"}
 
       {:error, reason} ->
         {:error, reason}

--- a/test/toolbox/workers/hexpm_worker_test.exs
+++ b/test/toolbox/workers/hexpm_worker_test.exs
@@ -104,4 +104,78 @@ defmodule Toolbox.Workers.HexpmWorkerTest do
       assert message =~ "502"
     end
   end
+
+  describe "perform/1 with get_package_owners" do
+    test "updates the package and broadcasts on success" do
+      test_server = Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      Phoenix.PubSub.subscribe(Toolbox.PubSub, "package_live:#{package.name}")
+
+      TestServer.add(test_server, "/packages/#{package.name}/owners",
+        to: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.send_resp(200, ~s([
+            {"email": "user@example.com", "username": "someuser"}
+          ]))
+        end
+      )
+
+      assert {:ok, %Toolbox.Package{} = updated} =
+               perform_job(HexpmWorker, %{
+                 action: "get_package_owners",
+                 name: package.name
+               })
+
+      assert [%{username: "someuser", email: "user@example.com"}] = updated.hexpm_owners
+      assert updated.hexpm_owners_sync_at
+
+      assert_receive %{
+        action: :refresh_owners,
+        owners: [%{username: "someuser"}]
+      }
+    end
+
+    @tag capture_log: true
+    test "returns :ok and skips the update on 404 (package removed from hex.pm)" do
+      test_server = Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      TestServer.add(test_server, "/packages/#{package.name}/owners",
+        to: fn conn ->
+          conn
+          |> Plug.Conn.put_resp_header("content-type", "application/json")
+          |> Plug.Conn.send_resp(404, ~s({"message": "Page not found", "status": 404}))
+        end
+      )
+
+      assert perform_job(HexpmWorker, %{
+               action: "get_package_owners",
+               name: package.name
+             }) == :ok
+
+      assert Packages.get_package_by_name(package.name).hexpm_owners == []
+    end
+
+    @tag capture_log: true
+    test "returns an error tuple on server errors so Oban retries" do
+      test_server = Helpers.test_server_hexpm()
+      {:ok, package} = create(:package)
+
+      TestServer.add(test_server, "/packages/#{package.name}/owners",
+        to: fn conn ->
+          Plug.Conn.send_resp(conn, 502, "")
+        end
+      )
+
+      assert {:error, message} =
+               perform_job(HexpmWorker, %{
+                 action: "get_package_owners",
+                 name: package.name
+               })
+
+      assert message =~ "502"
+    end
+  end
 end


### PR DESCRIPTION
### Describe what this PR includes

Addresses issue #274

This PR fixes `Toolbox.Workers.HexpmWorker` crashing with a `MatchError` when Hex.pm returns a non-200 status while fetching a package's owners.

This happens when a package already tracked gets removed from Hex.pm ([allowed within a short window after publish, or by Hex.pm's own moderation](https://hex.pm/docs/faq#can-packages-be-removed-from-the-repository)), so when a user visits that package's page, the app tries to refresh its owners and Hex.pm now returns a 404, which crashed the job.

### Changes

- Handle non-200 responses from `Toolbox.Hexpm.get_package_owners/1` instead of crashing. Log a warning and complete the job for 400/404, return an error so Oban retries for 5xx.

### Testing

- Add tests for `HexpmWorker.perform/1` (`get_package_owners`) covering a successful fetch, a 404 (package removed from Hex.pm), and a 5xx response.
