### PR TITLE
Fix scm worker merged by null

### DIFF
--- a/lib/toolbox/github_snapshot/pull_request.ex
+++ b/lib/toolbox/github_snapshot/pull_request.ex
@@ -22,8 +22,12 @@ defmodule Toolbox.GithubSnapshot.PullRequest do
       :merged_by_login
     ]
 
+    # mergedBy is null for PRs merged by a deleted account
+    # thats why those fields are not required
+    required_fields = fields -- [:merged_by_avatar_url, :merged_by_login]
+
     pr
     |> cast(attrs, fields)
-    |> validate_required(fields)
+    |> validate_required(required_fields)
   end
 end

--- a/lib/toolbox_web.ex
+++ b/lib/toolbox_web.ex
@@ -159,6 +159,13 @@ defmodule ToolboxWeb do
 
         "https://www.gravatar.com/avatar/#{hash}?s=#{size}&d=retro"
       end
+
+      # GitHub shows merges by deleted accounts as the "ghost" user
+      def merged_by_login(nil), do: "ghost"
+      def merged_by_login(login), do: login
+
+      def merged_by_avatar_url(nil), do: "https://github.com/ghost.png"
+      def merged_by_avatar_url(avatar_url), do: avatar_url
     end
   end
 

--- a/lib/toolbox_web/components/package_activity.ex
+++ b/lib/toolbox_web/components/package_activity.ex
@@ -109,16 +109,16 @@ defmodule ToolboxWeb.Components.PackageActivity do
                     <div class="flex mt-1">
                       <img
                         class="w-6 rounded-full"
-                        src={pr.merged_by_avatar_url}
+                        src={merged_by_avatar_url(pr.merged_by_avatar_url)}
                         {test_attrs(pr_avatar: true)}
                       />
                       <.link
-                        href={"https://github.com/#{pr.merged_by_login}"}
+                        href={"https://github.com/#{merged_by_login(pr.merged_by_login)}"}
                         target="_blank"
                         class="text-[14px] ml-2 hover:underline"
                         {test_attrs(pr_author: true)}
                       >
-                        {pr.merged_by_login}
+                        {merged_by_login(pr.merged_by_login)}
                       </.link>
                       <% {merged_at_number, merged_at_relative_label} =
                         relative_datetime(pr.merged_at) %>

--- a/test/toolbox/github_snapshot/pull_request_test.exs
+++ b/test/toolbox/github_snapshot/pull_request_test.exs
@@ -1,0 +1,22 @@
+defmodule Toolbox.GithubSnapshot.PullRequestTest do
+  use Toolbox.DataCase
+
+  alias Toolbox.GithubSnapshot.PullRequest
+
+  describe "changeset/2" do
+    test "merged_by_login and merged_by_avatar_url can be blank" do
+      attrs = %{
+        permalink: "https://github.com/owner/repo/pull/1",
+        created_at: ~U[2026-05-23 16:57:23Z],
+        title: "Streamline keepalive logic",
+        merged_at: ~U[2026-05-25 16:58:30Z],
+        merged_by_login: nil,
+        merged_by_avatar_url: nil
+      }
+
+      changeset = PullRequest.changeset(%PullRequest{}, attrs)
+
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/toolbox_web/components/package_activity_test.exs
+++ b/test/toolbox_web/components/package_activity_test.exs
@@ -150,6 +150,47 @@ defmodule ToolboxWeb.Components.PackageActivityTest do
       assert node_count(pr_dividers) >= 1
     end
 
+    test "renders GitHub's ghost user as fallback when merged_by is nil" do
+      activity = %Activity{
+        open_issue_count: 0,
+        closed_issue_count: 0,
+        open_pr_count: 0,
+        merged_pr_count: 1,
+        pull_requests: [
+          %PullRequest{
+            title: "Fix bug in authentication",
+            permalink: "https://github.com/owner/repo/pull/123",
+            merged_by_login: nil,
+            merged_by_avatar_url: nil,
+            merged_at: ~U[2024-01-15 10:30:00Z]
+          }
+        ]
+      }
+
+      html =
+        render_component(&package_activity/1,
+          activity: activity,
+          github_fullname: "owner/repo"
+        )
+
+      doc = LazyHTML.from_document(html)
+
+      # Check the PR is rendered
+      pr_items = LazyHTML.query(doc, "[data-test-pr-item]")
+      assert node_count(pr_items) == 1
+
+      # Check the ghost avatar is used as fallback
+      pr_avatars = LazyHTML.query(doc, "[data-test-pr-avatar]")
+      assert node_count(pr_avatars) == 1
+      assert LazyHTML.attribute(pr_avatars, "src") == ["https://github.com/ghost.png"]
+
+      # Check the ghost user is used as fallback author
+      pr_authors = LazyHTML.query(doc, "[data-test-pr-author]")
+      assert node_count(pr_authors) == 1
+      assert LazyHTML.attribute(pr_authors, "href") == ["https://github.com/ghost"]
+      assert LazyHTML.text(pr_authors) =~ "ghost"
+    end
+
     test "renders activity section with no pull requests" do
       activity = %Activity{
         open_issue_count: 0,


### PR DESCRIPTION
### Describe what this PR includes

This PR fixes `Toolbox.Workers.SCMWorker` crashing with an `Oban.PerformError` when a GitHub pull request was merged by an account that has since been deleted.

This happens because GitHub's API returns `mergedBy: null` for those PRs, but `Toolbox.GithubSnapshot.PullRequest` changeset required `merged_by_login` and `merged_by_avatar_url`, so the changeset became invalid and `Repo.insert_or_update` failed, crashing the job.

### Changes

- Stop requiring `merged_by_login` and `merged_by_avatar_url` on `PullRequest.changeset/2`.
- Fall back to GitHub's own "ghost" user (https://github.com/ghost) when rendering a merged PR with no merged_by, consistent with how GitHub displays it.

### Testing

- Add a test for `PullRequest.changeset/2` covering `merged_by_login` and `merged_by_avatar_url` being blank.
- Add a test for `PackageActivity` covering the ghost user fallback.

### Sreenshots

<img width="1470" height="586" alt="image" src="https://github.com/user-attachments/assets/c57a4d39-c026-4c3d-a1eb-a2751e88cc3d" />
